### PR TITLE
`workspace: centralize default detection markers and include .ragcode`

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -78,3 +78,13 @@ jobs:
           git add -f bin/
           git commit -m "chore: auto-build binaries [skip ci]"
           git push
+
+      - name: Create pull request with updated binaries (main only)
+        if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && steps.check_changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "chore: update binaries"
+          body: "Auto-generated PR to update binaries after code changes."
+          branch: "chore/update-binaries"
+          base: ${{ github.event.pull_request.base.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ Thumbs.db
 
 # Logs
 *.log
+.DO
 
 # Environment
 .env

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 RagCode is a **Model Context Protocol (MCP) server** that instantly makes your project **AI-ready**. It enables AI assistants like **GitHub Copilot**, **Cursor**, **Windsurf**, and **Claude** to understand your entire codebase through **semantic vector search**, bridging the gap between your code and Large Language Models (LLMs).
 
-Built with the official [Model Context Protocol Go SDK](https://github.com/modelcontextprotocol/go-sdk), RagCode provides **9 powerful tools** to index, search, and analyze code, making it the ultimate solution for **AI-ready software development**.
+Built with the official [Model Context Protocol Go SDK](https://github.com/modelcontextprotocol/go-sdk), RagCode provides **11 powerful tools** to index, search, analyze code, and manage **AI Skills**, making it the ultimate solution for **AI-ready software development**.
 
 ## ⚡ One-Command Installation
 
@@ -158,7 +158,7 @@ First query triggers background indexing. Subsequent queries are instant.
 
 ---
 
-## 🛠️ 9 Powerful MCP Tools
+## 🛠️ 11 Powerful MCP Tools
 
 | Tool | Description | Use When |
 |------|-------------|----------|
@@ -171,6 +171,8 @@ First query triggers background indexing. Subsequent queries are instant.
 | `search_docs` | Search Markdown documentation | Setup, architecture info |
 | `get_code_context` | Code snippet with context | Have file:line reference |
 | `index_workspace` | Reindex codebase | After major changes |
+| `list_skills` | List available AI behaviors | Discover new capabilities |
+| `install_skill` | Activate/Deactivate a skill | Enforce project rules |
 
 📖 **[Full Tool Reference →](./docs/tool_schema_v2.md)**
 
@@ -191,6 +193,21 @@ First query triggers background indexing. Subsequent queries are instant.
 RagCode automatically detects and manages multiple workspaces with isolated indexes.
 
 📖 **[Workspace Detection →](./internal/workspace/README.md)** - Auto-detection, stable IDs, caching
+
+---
+
+## 🧠 AI Skills System
+
+RagCode includes a **Skills System** that allows you to "install" specific behaviors and best practices into your AI assistant.
+
+**What is a Skill?**
+A skill is a package of instructions (prompts) and context that tells the AI specifically how to behave in your project (e.g., "Always use table-driven tests", "Follow Laravel directory structure").
+
+**Key Tools:**
+- `list_skills`: View bundled skills (like `go-best-practices`, `debugging-guide`).
+- `install_skill`: Activate a bundled skill in your workspace.
+
+📖 **[Full Skills Documentation →](./docs/SKILLS.md)**
 
 ---
 

--- a/cmd/rag-code-mcp/main.go
+++ b/cmd/rag-code-mcp/main.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	Version = "1.1.21"
+	Version = "1.2.0"
 	Commit  = "none"
 	Date    = "unknown"
 	// Build trigger: Python analyzer support
@@ -647,7 +647,7 @@ func main() {
 
 	indexWorkspaceTool := tools.NewIndexWorkspaceTool(workspaceManager)
 
-	listSkillsTool := tools.NewListSkillsTool()
+	listSkillsTool := tools.NewListSkillsTool(workspaceManager)
 	installSkillTool := tools.NewInstallSkillTool(workspaceManager)
 	checkUpdateTool := tools.NewCheckUpdateTool(Version)
 	applyUpdateTool := tools.NewApplyUpdateTool(Version)

--- a/cmd/rag-code-mcp/main.go
+++ b/cmd/rag-code-mcp/main.go
@@ -615,6 +615,9 @@ func main() {
 		cfg,
 	)
 
+	// Strategy 1: Migrate previously indexed workspaces into the persistent registry
+	workspaceManager.MigrateExistingWorkspaces()
+
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "ragcode",
 		Version: Version,

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -1,0 +1,83 @@
+# 🧠 AI Skills System
+
+RagCode MCP uses a **Skills System** to enforce project-specific behaviors, best practices, and workflows. A "Skill" is a structured set of instructions that tells the AI exactly how to operate within your codebase.
+
+---
+
+## 🚀 Managing Skills
+
+### 1. Bundled Skills (Embedded)
+These are skills that come built-in with the RagCode binary (e.g., `go-best-practices`, `debugging-guide`).
+
+**To enable a bundled skill:**
+Use the `install_skill` tool. This copies the skill files from the binary into your workspace's `.agent/skills/` directory.
+
+```javascript
+// Install (activate) a bundled skill
+install_skill(skill_id="go-best-practices", active=true)
+
+// Uninstall (deactivate)
+install_skill(skill_id="go-best-practices", active=false)
+```
+
+### 2. Custom Skills (User Created)
+You can create your own skills specific to your project.
+
+**To create (and automatically enable) a custom skill:**
+Simply create the skill file directly in the `.agent/skills/` directory.
+
+**Path:** `.agent/skills/<skill-id>/SKILL.md`
+
+**Required YAML Frontmatter:**
+You **MUST** include the `compatible-with` field.
+
+```markdown
+---
+name: <human-readable-name>
+description: <short-description-of-functionality>
+compatible-with: [rag-code-mcp]
+---
+
+# 🦸 Skill: [Name]
+... contents ...
+```
+
+**Note:** Custom skills created in this folder are **active by default**. You do NOT need to run `install_skill` for them. The `install_skill` tool only works for installing skills *from* the embedded library or external sources. It cannot "install" a skill that is already manually placed in the destination folder.
+
+---
+
+## 📦 Bundled Skills Reference
+
+| Skill ID | Description |
+|----------|-------------|
+| **`ragcode-priority`** | **MANDATORY**. Enforces using RagCode tools (`search_code`) over grep. |
+| **`debugging-guide`** | A 3-step reasoning workflow for root-cause analysis. |
+| **`go-best-practices`** | Official Go project layout and patterns. |
+| **`python-best-practices`** | Python PEP 8, typing, and testing standards. |
+| **`php-laravel`** | Laravel architecture and Eloquent patterns. |
+| **`ragcode-update`** | Workflows for updating the MCP server and managing skills. |
+
+---
+
+## 📝 Example `SKILL.md`
+
+```markdown
+---
+name: secure-coding
+description: Enforces security best practices for API endpoints.
+compatible-with: [rag-code-mcp]
+---
+
+# 🛡️ Skill: Secure Coding
+
+## 🎯 Purpose
+To prevent common OWASP vulnerabilities in our API.
+
+## ✅ Mandatory Rules
+1. **Input Validation**: All request parameters must be validated using the `validator` library.
+2. **Output Encoding**: Never output raw user input to HTML.
+
+## ⛔ Forbidden
+- Do NOT use `exec()` or `system()` with user input.
+- Do NOT commit secrets or API keys.
+```

--- a/docs/tool_schema_v2.md
+++ b/docs/tool_schema_v2.md
@@ -181,6 +181,21 @@ type SymbolDescriptor struct {
 - `list_package_exports` with `output_format: "json"` (Go + PHP).
 - Search-oriented tools (planned) to return compact hits.
 
+### 2.5. `SkillInfo` – Skills System
+
+```go
+type SkillInfo struct {
+    ID          string `json:"id"`
+    Name        string `json:"name"`
+    Description string `json:"description"`
+    Source      string `json:"source,omitempty"` // "binary" or absolute path
+}
+```
+
+**Used by:**
+- `list_skills` with `output_format: "json"`.
+
+
 ---
 
 ## 3. Mapping: tool → input → output
@@ -216,6 +231,22 @@ type SymbolDescriptor struct {
 - **Output:**
   - `markdown` – structured list grouped by kind (function/type/class/etc.).
   - `json` – `[]SymbolDescriptor`.
+
+### 3.4. `list_skills`
+
+- **Standard input:** (none)
+- **Output:**
+  - `markdown` – human-friendly list of available skills.
+  - `json` – `[]SkillInfo`.
+
+### 3.5. `install_skill`
+
+- **Standard input:**
+  - `skill_id` (required),
+  - `active` (boolean; required),
+  - `file_path` / `workspace_root` (optional; for workspace detection).
+- **Output:**
+  - Text confirmation of success or error.
 
 ---
 

--- a/internal/skills/embedded/debugging-guide/SKILL.md
+++ b/internal/skills/embedded/debugging-guide/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: debugging-guide
-description: How to use ragcode tools for fast root-cause analysis and debugging
+description: RECOMMENDED 3-step reasoning workflow for debugging and root-cause analysis with ragcode tools.
+compatible-with: [rag-code-mcp]
 ---
 
 # 🐞 Skill: Debugging with Ragcode

--- a/internal/skills/embedded/go-best-practices/SKILL.md
+++ b/internal/skills/embedded/go-best-practices/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: go-best-practices
-description: Go development patterns, project structure, and idiomatic practices
+description: OFFICIAL Go development patterns and project structure. MANDATORY for all Go coding tasks in this workspace.
+compatible-with: [rag-code-mcp]
 ---
 
 # 🐹 Skill: Go Best Practices

--- a/internal/skills/embedded/php-laravel/SKILL.md
+++ b/internal/skills/embedded/php-laravel/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: php-laravel
-description: PHP and Laravel specific patterns, Service Providers, and Eloquent practices
+description: OFFICIAL Laravel/PHP patterns and Eloquent practices. Use these rules for all PHP development.
+compatible-with: [rag-code-mcp]
 ---
 
 # 🐘 Skill: PHP & Laravel Patterns

--- a/internal/skills/embedded/python-best-practices/SKILL.md
+++ b/internal/skills/embedded/python-best-practices/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: python-best-practices
-description: Python patterns, type hinting, and project standards
+description: OFFICIAL Python project standards and type hinting rules. MANDATORY to follow.
+compatible-with: [rag-code-mcp]
 ---
 
 # 🐍 Skill: Python Best Practices

--- a/internal/skills/embedded/ragcode-priority/SKILL.md
+++ b/internal/skills/embedded/ragcode-priority/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ragcode-priority
 description: Prioritize ragcode MCP tools for all code searches in this project
+compatible-with: [rag-code-mcp]
 ---
 
 # 🎯 Skill: Ragcode MCP Priority Usage

--- a/internal/skills/embedded/ragcode-update/SKILL.md
+++ b/internal/skills/embedded/ragcode-update/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ragcode-update
 description: Guide for managing ragcode updates, health checks, and AI skills
+compatible-with: [rag-code-mcp]
 ---
 
 # 🛠️ Skill: Ragcode Maintenance & Updates

--- a/internal/skills/embedded/ragcode-update/SKILL.md
+++ b/internal/skills/embedded/ragcode-update/SKILL.md
@@ -39,12 +39,18 @@ When the user wants to enhance your capabilities:
 2. Explain what each skill does based on its description.
 3. Use `install_skill(skill_id, active=true)` to enable it.
 
+Example MCP call:
+```
+mcp_ragcode_install_skill(skill_id="ragcode-update", active=true, file_path="/home/user/project/go.mod")
+```
+
 ---
 
 ## 🏥 Health Checks
 If the system feels slow or tools fail consistently:
 1. Suggest running the health check (CLI flag `--health`).
 2. Check if the workspace is indexed. If not, suggest `index_workspace`.
+3. Dacă indexarea pare suspectă sau inconsecventă, rulează explicit `index_workspace` cu `file_path` sau `workspace_root` (ex.: `mcp_ragcode_index_workspace(file_path="/home/user/project/go.mod")`) pentru a forța verificarea colecțiilor și reindexarea.
 
 ---
 

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -22,32 +22,128 @@ type SkillInfo struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
+	Source      string `json:"source,omitempty"` // "binary" or absolute path to source
 }
 
-// ListAvailableSkills scans the embedded filesystem for skills and extracts metadata from SKILL.md
+var externalSkillsPaths []string
+
+// AddExternalSkillsPath adds a directory to be scanned for skills
+func AddExternalSkillsPath(path string) {
+	if path == "" {
+		return
+	}
+	abs, err := filepath.Abs(path)
+	if err == nil {
+		path = abs
+	}
+	// Avoid duplicates
+	for _, p := range externalSkillsPaths {
+		if p == path {
+			return
+		}
+	}
+	externalSkillsPaths = append(externalSkillsPaths, path)
+}
+
+// ListAvailableSkills scans the embedded filesystem and external paths for skills
 func ListAvailableSkills() ([]SkillInfo, error) {
 	var available []SkillInfo
+	seen := make(map[string]bool)
 
+	// 1. Scan embedded skills
 	entries, err := embeddedSkills.ReadDir("embedded")
-	if err != nil {
-		return nil, fmt.Errorf("failed to read embedded skills: %w", err)
+	if err == nil {
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			skillID := entry.Name()
+			info, err := GetSkillMetadata(skillID)
+			if err == nil {
+				info.Source = "binary"
+				available = append(available, info)
+				seen[skillID] = true
+			}
+		}
 	}
 
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
+	// 2. Scan external paths recursively
+	for _, rootPath := range externalSkillsPaths {
+		err := filepath.WalkDir(rootPath, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return nil // Skip unreadable paths
+			}
 
-		skillID := entry.Name()
-		info, err := GetSkillMetadata(skillID)
+			// We are looking for SKILL.md files
+			if d.IsDir() || d.Name() != "SKILL.md" {
+				return nil
+			}
+
+			// Found a SKILL.md file!
+			// The skill ID is the name of the parent directory
+			skillDir := filepath.Dir(path)
+			skillID := filepath.Base(skillDir)
+
+			if seen[skillID] {
+				return nil
+			}
+
+			// Get metadata from this specific file path and CHECK COMPATIBILITY
+			info, err := GetExternalSkillMetadataFromFile(path, skillID)
+			if err == nil {
+				info.Source = skillDir
+				available = append(available, info)
+				seen[skillID] = true
+			}
+			return nil
+		})
 		if err != nil {
-			// Skip skills with invalid metadata but log or handle as needed
-			continue
+			fmt.Fprintf(os.Stderr, "Error scanning external skills path %s: %v\n", rootPath, err)
 		}
-		available = append(available, info)
 	}
 
 	return available, nil
+}
+
+// GetExternalSkillMetadataFromFile extracts metadata from a specific SKILL.md file path
+func GetExternalSkillMetadataFromFile(filePath, skillID string) (SkillInfo, error) {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return SkillInfo{}, fmt.Errorf("failed to read SKILL.md from %s: %w", filePath, err)
+	}
+
+	parts := strings.Split(string(content), "---")
+	if len(parts) < 3 {
+		return SkillInfo{}, fmt.Errorf("invalid frontmatter in SKILL.md for %s", skillID)
+	}
+
+	var metadata struct {
+		Name           string   `yaml:"name"`
+		Description    string   `yaml:"description"`
+		CompatibleWith []string `yaml:"compatible-with"`
+	}
+
+	if err := yaml.Unmarshal([]byte(parts[1]), &metadata); err != nil {
+		return SkillInfo{}, fmt.Errorf("failed to parse metadata for %s: %w", skillID, err)
+	}
+
+	// Filter: Check compatibility
+	isCompatible := false
+	for _, comp := range metadata.CompatibleWith {
+		if comp == "rag-code-mcp" {
+			isCompatible = true
+			break
+		}
+	}
+	if !isCompatible {
+		return SkillInfo{}, fmt.Errorf("skill %s is not compatible with rag-code-mcp", skillID)
+	}
+
+	return SkillInfo{
+		ID:          skillID,
+		Name:        metadata.Name,
+		Description: metadata.Description,
+	}, nil
 }
 
 // GetSkillMetadata extracts metadata from the SKILL.md of a specific skill
@@ -65,12 +161,25 @@ func GetSkillMetadata(skillID string) (SkillInfo, error) {
 	}
 
 	var metadata struct {
-		Name        string `yaml:"name"`
-		Description string `yaml:"description"`
+		Name           string   `yaml:"name"`
+		Description    string   `yaml:"description"`
+		CompatibleWith []string `yaml:"compatible-with"`
 	}
 
 	if err := yaml.Unmarshal([]byte(parts[1]), &metadata); err != nil {
 		return SkillInfo{}, fmt.Errorf("failed to parse metadata for %s: %w", skillID, err)
+	}
+
+	// Filter: Check compatibility
+	isCompatible := false
+	for _, comp := range metadata.CompatibleWith {
+		if comp == "rag-code-mcp" {
+			isCompatible = true
+			break
+		}
+	}
+	if !isCompatible {
+		return SkillInfo{}, fmt.Errorf("skill %s is not compatible with rag-code-mcp (missing 'compatible-with: [rag-code-mcp]')", skillID)
 	}
 
 	return SkillInfo{
@@ -99,39 +208,95 @@ func InstallSkill(skillID string, workspaceRoot string) error {
 	// Note: This might be redundant with validateSkillID but good for defense in depth
 	// However, workspaceRoot might be relative or absolute, so we rely on skillID validation primarily.
 
+	// Try embedded first
 	srcDir := "embedded/" + skillID
+	if _, err := embeddedSkills.ReadDir(srcDir); err == nil {
+		// Verify compatibility before installing
+		if _, err := GetSkillMetadata(skillID); err != nil {
+			return fmt.Errorf("skill '%s' is not compatible: %w", skillID, err)
+		}
 
-	// Verify the skill exists in embedded FS before trying to walk
-	if _, err := embeddedSkills.ReadDir(srcDir); err != nil {
-		return fmt.Errorf("skill '%s' not found in embedded library", skillID)
+		return fs.WalkDir(embeddedSkills, srcDir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			relPath, err := filepath.Rel(srcDir, path)
+			if err != nil {
+				return err
+			}
+
+			targetPath := filepath.Join(destDir, relPath)
+
+			if d.IsDir() {
+				return os.MkdirAll(targetPath, 0755)
+			}
+
+			content, err := embeddedSkills.ReadFile(path)
+			if err != nil {
+				return err
+			}
+
+			return os.WriteFile(targetPath, content, 0644)
+		})
 	}
 
-	return fs.WalkDir(embeddedSkills, srcDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
+	// Try external paths RECURSIVELY
+	for _, rootPath := range externalSkillsPaths {
+		var foundDir string
+		var foundPath string
+
+		// Walk to find the skill directory
+		_ = filepath.WalkDir(rootPath, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			// Look for the folder that matches skillID AND contains SKILL.md
+			if d.IsDir() && d.Name() == skillID {
+				// Verify it has a SKILL.md inside
+				skillMdPath := filepath.Join(path, "SKILL.md")
+				if _, err := os.Stat(skillMdPath); err == nil {
+					foundDir = path
+					foundPath = skillMdPath
+					return fs.SkipAll // Stop searching once found
+				}
+			}
+			return nil
+		})
+
+		if foundDir != "" {
+			// Verify compatibility before installing
+			if _, err := GetExternalSkillMetadataFromFile(foundPath, skillID); err != nil {
+				return fmt.Errorf("skill '%s' found but is not compatible: %w", skillID, err)
+			}
+
+			return filepath.Walk(foundDir, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+
+				relPath, err := filepath.Rel(foundDir, path)
+				if err != nil {
+					return err
+				}
+
+				targetPath := filepath.Join(destDir, relPath)
+
+				if info.IsDir() {
+					return os.MkdirAll(targetPath, 0755)
+				}
+
+				content, err := os.ReadFile(path)
+				if err != nil {
+					return err
+				}
+
+				return os.WriteFile(targetPath, content, 0644)
+			})
 		}
+	}
 
-		// Calculate relative path from skill root
-		relPath, err := filepath.Rel(srcDir, path)
-		if err != nil {
-			return err
-		}
-
-		// Join with destination directory
-		targetPath := filepath.Join(destDir, relPath)
-
-		if d.IsDir() {
-			return os.MkdirAll(targetPath, 0755)
-		}
-
-		// Read from embed and write to disk
-		content, err := embeddedSkills.ReadFile(path)
-		if err != nil {
-			return err
-		}
-
-		return os.WriteFile(targetPath, content, 0644)
-	})
+	return fmt.Errorf("skill '%s' not found", skillID)
 }
 
 // UninstallSkill removes a skill from the workspace
@@ -141,4 +306,14 @@ func UninstallSkill(skillID string, workspaceRoot string) error {
 	}
 	destDir := filepath.Join(workspaceRoot, ".agent", "skills", skillID)
 	return os.RemoveAll(destDir)
+}
+
+// IsSkillInstalled checks if a skill is installed in the workspace
+func IsSkillInstalled(skillID string, workspaceRoot string) bool {
+	destDir := filepath.Join(workspaceRoot, ".agent", "skills", skillID)
+	// Check if directory exists and has SKILL.md
+	if _, err := os.Stat(filepath.Join(destDir, "SKILL.md")); err == nil {
+		return true
+	}
+	return false
 }

--- a/internal/tools/find_implementations.go
+++ b/internal/tools/find_implementations.go
@@ -53,52 +53,44 @@ func (t *FindImplementationsTool) Execute(ctx context.Context, args map[string]i
 		packagePath = pkg
 	}
 
-	// file_path with single-workspace fallback (no error - defers to DetectWorkspace)
-	resolveFilePathWithFallback(args, t.workspaceManager, "find_implementations")
-
-	// Try workspace detection if workspace manager is available
+	// Resolve workspace from registry
 	var searchMemory memory.LongTermMemory
 	var workspacePath string
 	var collectionName string
 
 	if t.workspaceManager != nil {
-		workspaceInfo, err := t.workspaceManager.DetectWorkspace(args)
-		if err == nil && workspaceInfo != nil {
-			workspacePath = workspaceInfo.Root
+		workspaceInfo, err := t.workspaceManager.ResolveWorkspace(args)
+		if err != nil {
+			return "", err
+		}
+		workspacePath = workspaceInfo.Root
 
-			// Detect language from file path or use first detected language
-			language := inferLanguageFromPath(extractFilePathFromParams(args))
-			if language == "" && len(workspaceInfo.Languages) > 0 {
-				language = workspaceInfo.Languages[0]
-			}
-			if language == "" {
-				language = workspaceInfo.ProjectType
+		language := ""
+		if len(workspaceInfo.Languages) > 0 {
+			language = workspaceInfo.Languages[0]
+		}
+
+		collectionName = workspaceInfo.CollectionNameForLanguage(language)
+		mem, err := t.workspaceManager.GetMemoryForWorkspaceLanguage(ctx, workspaceInfo, language)
+		if err == nil && mem != nil {
+			indexKey := workspaceInfo.ID + "-" + language
+			if t.workspaceManager.IsIndexing(indexKey) {
+				return fmt.Sprintf("⏳ Workspace '%s' language '%s' is currently being indexed in the background.\n"+
+					"Please try again in a few moments.\n"+
+					"Workspace: %s\n"+
+					"Language: %s\n"+
+					"Collection: %s",
+					workspaceInfo.Root, language, workspaceInfo.Root, language, collectionName), nil
 			}
 
-			collectionName = workspaceInfo.CollectionNameForLanguage(language)
-			mem, err := t.workspaceManager.GetMemoryForWorkspaceLanguage(ctx, workspaceInfo, language)
-			if err == nil && mem != nil {
-				// Check if indexing is in progress
-				indexKey := workspaceInfo.ID + "-" + language
-				if t.workspaceManager.IsIndexing(indexKey) {
-					return fmt.Sprintf("⏳ Workspace '%s' language '%s' is currently being indexed in the background.\n"+
-						"Please try again in a few moments.\n"+
-						"Workspace: %s\n"+
-						"Language: %s\n"+
-						"Collection: %s",
-						workspaceInfo.Root, language, workspaceInfo.Root, language, collectionName), nil
+			if msg, err := CheckCollectionStatus(ctx, mem, collectionName, workspacePath); err != nil || msg != "" {
+				if err != nil {
+					return "", err
 				}
-
-				// Check if collection exists before proceeding
-				if msg, err := CheckCollectionStatus(ctx, mem, collectionName, workspacePath); err != nil || msg != "" {
-					if err != nil {
-						return "", err
-					}
-					return msg, nil
-				}
-
-				searchMemory = mem
+				return msg, nil
 			}
+
+			searchMemory = mem
 		}
 	}
 

--- a/internal/tools/find_implementations.go
+++ b/internal/tools/find_implementations.go
@@ -53,12 +53,8 @@ func (t *FindImplementationsTool) Execute(ctx context.Context, args map[string]i
 		packagePath = pkg
 	}
 
-	// file_path with single-workspace fallback
-	filePath, err := resolveFilePathWithFallback(args, t.workspaceManager, "find_implementations")
-	if err != nil {
-		return "", err
-	}
-	_ = filePath
+	// file_path with single-workspace fallback (no error - defers to DetectWorkspace)
+	resolveFilePathWithFallback(args, t.workspaceManager, "find_implementations")
 
 	// Try workspace detection if workspace manager is available
 	var searchMemory memory.LongTermMemory
@@ -71,7 +67,7 @@ func (t *FindImplementationsTool) Execute(ctx context.Context, args map[string]i
 			workspacePath = workspaceInfo.Root
 
 			// Detect language from file path or use first detected language
-			language := inferLanguageFromPath(filePath)
+			language := inferLanguageFromPath(extractFilePathFromParams(args))
 			if language == "" && len(workspaceInfo.Languages) > 0 {
 				language = workspaceInfo.Languages[0]
 			}

--- a/internal/tools/find_implementations.go
+++ b/internal/tools/find_implementations.go
@@ -53,11 +53,12 @@ func (t *FindImplementationsTool) Execute(ctx context.Context, args map[string]i
 		packagePath = pkg
 	}
 
-	// file_path is required for workspace detection
-	filePath := extractFilePathFromParams(args)
-	if filePath == "" {
-		return "", fmt.Errorf("file_path parameter is required for find_implementations. Please provide a file path from your workspace")
+	// file_path with single-workspace fallback
+	filePath, err := resolveFilePathWithFallback(args, t.workspaceManager, "find_implementations")
+	if err != nil {
+		return "", err
 	}
+	_ = filePath
 
 	// Try workspace detection if workspace manager is available
 	var searchMemory memory.LongTermMemory

--- a/internal/tools/find_type_definition.go
+++ b/internal/tools/find_type_definition.go
@@ -61,11 +61,12 @@ func (t *FindTypeDefinitionTool) Execute(ctx context.Context, args map[string]in
 		outputFormat = strings.ToLower(of)
 	}
 
-	// file_path is required for workspace detection
-	filePath := extractFilePathFromParams(args)
-	if filePath == "" {
-		return "", fmt.Errorf("file_path parameter is required for find_type_definition. Please provide a file path from your workspace")
+	// file_path with single-workspace fallback
+	filePath, err := resolveFilePathWithFallback(args, t.workspaceManager, "find_type_definition")
+	if err != nil {
+		return "", err
 	}
+	_ = filePath
 
 	// Try workspace detection if workspace manager is available
 	var searchMemory memory.LongTermMemory

--- a/internal/tools/find_type_definition.go
+++ b/internal/tools/find_type_definition.go
@@ -61,12 +61,8 @@ func (t *FindTypeDefinitionTool) Execute(ctx context.Context, args map[string]in
 		outputFormat = strings.ToLower(of)
 	}
 
-	// file_path with single-workspace fallback
-	filePath, err := resolveFilePathWithFallback(args, t.workspaceManager, "find_type_definition")
-	if err != nil {
-		return "", err
-	}
-	_ = filePath
+	// file_path with single-workspace fallback (no error - defers to DetectWorkspace)
+	resolveFilePathWithFallback(args, t.workspaceManager, "find_type_definition")
 
 	// Try workspace detection if workspace manager is available
 	var searchMemory memory.LongTermMemory
@@ -79,7 +75,7 @@ func (t *FindTypeDefinitionTool) Execute(ctx context.Context, args map[string]in
 			workspacePath = workspaceInfo.Root
 
 			// Detect language from file path or use first detected language
-			language := inferLanguageFromPath(filePath)
+			language := inferLanguageFromPath(extractFilePathFromParams(args))
 			if language == "" && len(workspaceInfo.Languages) > 0 {
 				language = workspaceInfo.Languages[0]
 			}
@@ -124,7 +120,7 @@ func (t *FindTypeDefinitionTool) Execute(ctx context.Context, args map[string]in
 	}
 
 	// Detect language from file path to build appropriate query
-	language := inferLanguageFromPath(filePath)
+	language := inferLanguageFromPath(extractFilePathFromParams(args))
 
 	// Search for the type in the vector database
 	// Use language-appropriate keywords for better semantic matching

--- a/internal/tools/find_type_definition.go
+++ b/internal/tools/find_type_definition.go
@@ -61,56 +61,47 @@ func (t *FindTypeDefinitionTool) Execute(ctx context.Context, args map[string]in
 		outputFormat = strings.ToLower(of)
 	}
 
-	// file_path with single-workspace fallback (no error - defers to DetectWorkspace)
-	resolveFilePathWithFallback(args, t.workspaceManager, "find_type_definition")
-
-	// Try workspace detection if workspace manager is available
+	// Resolve workspace from registry
 	var searchMemory memory.LongTermMemory
 	var workspacePath string
 	var collectionName string
+	var detectedLang string
 
 	if t.workspaceManager != nil {
-		workspaceInfo, err := t.workspaceManager.DetectWorkspace(args)
-		if err == nil && workspaceInfo != nil {
-			workspacePath = workspaceInfo.Root
+		workspaceInfo, err := t.workspaceManager.ResolveWorkspace(args)
+		if err != nil {
+			return "", err
+		}
+		workspacePath = workspaceInfo.Root
 
-			// Detect language from file path or use first detected language
-			language := inferLanguageFromPath(extractFilePathFromParams(args))
-			if language == "" && len(workspaceInfo.Languages) > 0 {
-				language = workspaceInfo.Languages[0]
-			}
-			if language == "" {
-				language = workspaceInfo.ProjectType
+		if len(workspaceInfo.Languages) > 0 {
+			detectedLang = workspaceInfo.Languages[0]
+		}
+
+		collectionName = workspaceInfo.CollectionNameForLanguage(detectedLang)
+		mem, err := t.workspaceManager.GetMemoryForWorkspaceLanguage(ctx, workspaceInfo, detectedLang)
+		if err == nil && mem != nil {
+			indexKey := workspaceInfo.ID + "-" + detectedLang
+			if t.workspaceManager.IsIndexing(indexKey) {
+				return fmt.Sprintf("⏳ Workspace '%s' language '%s' is currently being indexed in the background.\n"+
+					"Please try again in a few moments.\n"+
+					"Workspace: %s\n"+
+					"Language: %s\n"+
+					"Collection: %s",
+					workspaceInfo.Root, detectedLang, workspaceInfo.Root, detectedLang, collectionName), nil
 			}
 
-			collectionName = workspaceInfo.CollectionNameForLanguage(language)
-			mem, err := t.workspaceManager.GetMemoryForWorkspaceLanguage(ctx, workspaceInfo, language)
-			if err == nil && mem != nil {
-				// Check if indexing is in progress
-				indexKey := workspaceInfo.ID + "-" + language
-				if t.workspaceManager.IsIndexing(indexKey) {
-					return fmt.Sprintf("⏳ Workspace '%s' language '%s' is currently being indexed in the background.\n"+
-						"Please try again in a few moments.\n"+
-						"Workspace: %s\n"+
-						"Language: %s\n"+
-						"Collection: %s",
-						workspaceInfo.Root, language, workspaceInfo.Root, language, collectionName), nil
+			if msg, err := CheckCollectionStatus(ctx, mem, collectionName, workspacePath); err != nil || msg != "" {
+				if err != nil {
+					return "", err
 				}
-
-				// Check if collection exists before proceeding
-				if msg, err := CheckCollectionStatus(ctx, mem, collectionName, workspacePath); err != nil || msg != "" {
-					if err != nil {
-						return "", err
-					}
-					return msg, nil
-				}
-
-				searchMemory = mem
+				return msg, nil
 			}
+
+			searchMemory = mem
 		}
 	}
 
-	// Use workspace-specific memory or fall back to default
 	if searchMemory == nil {
 		searchMemory = t.longTermMemory
 	}
@@ -119,8 +110,7 @@ func (t *FindTypeDefinitionTool) Execute(ctx context.Context, args map[string]in
 		return "", fmt.Errorf("no long-term memory configured")
 	}
 
-	// Detect language from file path to build appropriate query
-	language := inferLanguageFromPath(extractFilePathFromParams(args))
+	language := detectedLang
 
 	// Search for the type in the vector database
 	// Use language-appropriate keywords for better semantic matching

--- a/internal/tools/get_function_details.go
+++ b/internal/tools/get_function_details.go
@@ -61,52 +61,44 @@ func (t *GetFunctionDetailsTool) Execute(ctx context.Context, args map[string]in
 		outputFormat = strings.ToLower(of)
 	}
 
-	// file_path with single-workspace fallback (no error - defers to DetectWorkspace)
-	resolveFilePathWithFallback(args, t.workspaceManager, "get_function_details")
-
-	// Try workspace detection if workspace manager is available
+	// Resolve workspace from registry
 	var searchMemory memory.LongTermMemory
 	var workspacePath string
 	var collectionName string
 
 	if t.workspaceManager != nil {
-		workspaceInfo, err := t.workspaceManager.DetectWorkspace(args)
-		if err == nil && workspaceInfo != nil {
-			workspacePath = workspaceInfo.Root
+		workspaceInfo, err := t.workspaceManager.ResolveWorkspace(args)
+		if err != nil {
+			return "", err
+		}
+		workspacePath = workspaceInfo.Root
 
-			// Detect language from file path or use first detected language
-			language := inferLanguageFromPath(extractFilePathFromParams(args))
-			if language == "" && len(workspaceInfo.Languages) > 0 {
-				language = workspaceInfo.Languages[0]
-			}
-			if language == "" {
-				language = workspaceInfo.ProjectType
+		language := ""
+		if len(workspaceInfo.Languages) > 0 {
+			language = workspaceInfo.Languages[0]
+		}
+
+		collectionName = workspaceInfo.CollectionNameForLanguage(language)
+		mem, err := t.workspaceManager.GetMemoryForWorkspaceLanguage(ctx, workspaceInfo, language)
+		if err == nil && mem != nil {
+			indexKey := workspaceInfo.ID + "-" + language
+			if t.workspaceManager.IsIndexing(indexKey) {
+				return fmt.Sprintf("⏳ Workspace '%s' language '%s' is currently being indexed in the background.\n"+
+					"Please try again in a few moments.\n"+
+					"Workspace: %s\n"+
+					"Language: %s\n"+
+					"Collection: %s",
+					workspaceInfo.Root, language, workspaceInfo.Root, language, collectionName), nil
 			}
 
-			collectionName = workspaceInfo.CollectionNameForLanguage(language)
-			mem, err := t.workspaceManager.GetMemoryForWorkspaceLanguage(ctx, workspaceInfo, language)
-			if err == nil && mem != nil {
-				// Check if indexing is in progress
-				indexKey := workspaceInfo.ID + "-" + language
-				if t.workspaceManager.IsIndexing(indexKey) {
-					return fmt.Sprintf("⏳ Workspace '%s' language '%s' is currently being indexed in the background.\n"+
-						"Please try again in a few moments.\n"+
-						"Workspace: %s\n"+
-						"Language: %s\n"+
-						"Collection: %s",
-						workspaceInfo.Root, language, workspaceInfo.Root, language, collectionName), nil
+			if msg, err := CheckCollectionStatus(ctx, mem, collectionName, workspacePath); err != nil || msg != "" {
+				if err != nil {
+					return "", err
 				}
-
-				// Check if collection exists before proceeding
-				if msg, err := CheckCollectionStatus(ctx, mem, collectionName, workspacePath); err != nil || msg != "" {
-					if err != nil {
-						return "", err
-					}
-					return msg, nil
-				}
-
-				searchMemory = mem
+				return msg, nil
 			}
+
+			searchMemory = mem
 		}
 	}
 

--- a/internal/tools/get_function_details.go
+++ b/internal/tools/get_function_details.go
@@ -61,11 +61,12 @@ func (t *GetFunctionDetailsTool) Execute(ctx context.Context, args map[string]in
 		outputFormat = strings.ToLower(of)
 	}
 
-	// file_path is required for workspace detection
-	filePath := extractFilePathFromParams(args)
-	if filePath == "" {
-		return "", fmt.Errorf("file_path parameter is required for get_function_details. Please provide a file path from your workspace")
+	// file_path with single-workspace fallback
+	filePath, err := resolveFilePathWithFallback(args, t.workspaceManager, "get_function_details")
+	if err != nil {
+		return "", err
 	}
+	_ = filePath
 
 	// Try workspace detection if workspace manager is available
 	var searchMemory memory.LongTermMemory

--- a/internal/tools/get_function_details.go
+++ b/internal/tools/get_function_details.go
@@ -61,12 +61,8 @@ func (t *GetFunctionDetailsTool) Execute(ctx context.Context, args map[string]in
 		outputFormat = strings.ToLower(of)
 	}
 
-	// file_path with single-workspace fallback
-	filePath, err := resolveFilePathWithFallback(args, t.workspaceManager, "get_function_details")
-	if err != nil {
-		return "", err
-	}
-	_ = filePath
+	// file_path with single-workspace fallback (no error - defers to DetectWorkspace)
+	resolveFilePathWithFallback(args, t.workspaceManager, "get_function_details")
 
 	// Try workspace detection if workspace manager is available
 	var searchMemory memory.LongTermMemory
@@ -79,7 +75,7 @@ func (t *GetFunctionDetailsTool) Execute(ctx context.Context, args map[string]in
 			workspacePath = workspaceInfo.Root
 
 			// Detect language from file path or use first detected language
-			language := inferLanguageFromPath(filePath)
+			language := inferLanguageFromPath(extractFilePathFromParams(args))
 			if language == "" && len(workspaceInfo.Languages) > 0 {
 				language = workspaceInfo.Languages[0]
 			}

--- a/internal/tools/hybrid_search.go
+++ b/internal/tools/hybrid_search.go
@@ -72,52 +72,44 @@ func (t *HybridSearchTool) Execute(ctx context.Context, params map[string]interf
 		outputFormat = strings.ToLower(of)
 	}
 
-	// file_path with single-workspace fallback (no error - defers to DetectWorkspace)
-	resolveFilePathWithFallback(params, t.workspaceManager, "hybrid_search")
-
-	// Try workspace detection
+	// Resolve workspace from registry
 	var workspaceMem memory.LongTermMemory
 	var workspacePath string
 	var collectionName string
 
 	if t.workspaceManager != nil {
-		workspaceInfo, err := t.workspaceManager.DetectWorkspace(params)
-		if err == nil && workspaceInfo != nil {
-			workspacePath = workspaceInfo.Root
+		workspaceInfo, err := t.workspaceManager.ResolveWorkspace(params)
+		if err != nil {
+			return "", err
+		}
+		workspacePath = workspaceInfo.Root
 
-			// Detect language from file path or use first detected language
-			language := inferLanguageFromPath(extractFilePathFromParams(params))
-			if language == "" && len(workspaceInfo.Languages) > 0 {
-				language = workspaceInfo.Languages[0]
-			}
-			if language == "" {
-				language = workspaceInfo.ProjectType
+		language := ""
+		if len(workspaceInfo.Languages) > 0 {
+			language = workspaceInfo.Languages[0]
+		}
+
+		collectionName = workspaceInfo.CollectionNameForLanguage(language)
+		mem, err := t.workspaceManager.GetMemoryForWorkspaceLanguage(ctx, workspaceInfo, language)
+		if err == nil && mem != nil {
+			indexKey := workspaceInfo.ID + "-" + language
+			if t.workspaceManager.IsIndexing(indexKey) {
+				return fmt.Sprintf("⏳ Workspace '%s' language '%s' is currently being indexed in the background.\n"+
+					"Please try again in a few moments.\n"+
+					"Workspace: %s\n"+
+					"Language: %s\n"+
+					"Collection: %s",
+					workspaceInfo.Root, language, workspaceInfo.Root, language, collectionName), nil
 			}
 
-			collectionName = workspaceInfo.CollectionNameForLanguage(language)
-			mem, err := t.workspaceManager.GetMemoryForWorkspaceLanguage(ctx, workspaceInfo, language)
-			if err == nil && mem != nil {
-				// Check if indexing is in progress
-				indexKey := workspaceInfo.ID + "-" + language
-				if t.workspaceManager.IsIndexing(indexKey) {
-					return fmt.Sprintf("⏳ Workspace '%s' language '%s' is currently being indexed in the background.\n"+
-						"Please try again in a few moments.\n"+
-						"Workspace: %s\n"+
-						"Language: %s\n"+
-						"Collection: %s",
-						workspaceInfo.Root, language, workspaceInfo.Root, language, collectionName), nil
+			if msg, err := CheckCollectionStatus(ctx, mem, collectionName, workspacePath); err != nil || msg != "" {
+				if err != nil {
+					return "", err
 				}
-
-				// Check if collection exists before proceeding
-				if msg, err := CheckCollectionStatus(ctx, mem, collectionName, workspacePath); err != nil || msg != "" {
-					if err != nil {
-						return "", err
-					}
-					return msg, nil
-				}
-
-				workspaceMem = mem
+				return msg, nil
 			}
+
+			workspaceMem = mem
 		}
 	}
 

--- a/internal/tools/hybrid_search.go
+++ b/internal/tools/hybrid_search.go
@@ -72,12 +72,8 @@ func (t *HybridSearchTool) Execute(ctx context.Context, params map[string]interf
 		outputFormat = strings.ToLower(of)
 	}
 
-	// file_path with single-workspace fallback
-	filePath, err := resolveFilePathWithFallback(params, t.workspaceManager, "hybrid_search")
-	if err != nil {
-		return "", err
-	}
-	_ = filePath
+	// file_path with single-workspace fallback (no error - defers to DetectWorkspace)
+	resolveFilePathWithFallback(params, t.workspaceManager, "hybrid_search")
 
 	// Try workspace detection
 	var workspaceMem memory.LongTermMemory
@@ -90,7 +86,7 @@ func (t *HybridSearchTool) Execute(ctx context.Context, params map[string]interf
 			workspacePath = workspaceInfo.Root
 
 			// Detect language from file path or use first detected language
-			language := inferLanguageFromPath(filePath)
+			language := inferLanguageFromPath(extractFilePathFromParams(params))
 			if language == "" && len(workspaceInfo.Languages) > 0 {
 				language = workspaceInfo.Languages[0]
 			}

--- a/internal/tools/hybrid_search.go
+++ b/internal/tools/hybrid_search.go
@@ -72,11 +72,12 @@ func (t *HybridSearchTool) Execute(ctx context.Context, params map[string]interf
 		outputFormat = strings.ToLower(of)
 	}
 
-	// file_path is required for workspace detection
-	filePath := extractFilePathFromParams(params)
-	if filePath == "" {
-		return "", fmt.Errorf("file_path parameter is required for hybrid_search. Please provide a file path from your workspace")
+	// file_path with single-workspace fallback
+	filePath, err := resolveFilePathWithFallback(params, t.workspaceManager, "hybrid_search")
+	if err != nil {
+		return "", err
 	}
+	_ = filePath
 
 	// Try workspace detection
 	var workspaceMem memory.LongTermMemory

--- a/internal/tools/index_workspace.go
+++ b/internal/tools/index_workspace.go
@@ -40,10 +40,17 @@ func (t *IndexWorkspaceTool) Execute(ctx context.Context, params map[string]inte
 		return "", fmt.Errorf("workspace manager not configured")
 	}
 
-	// Detect workspace from params
+	// Detect workspace from params (walk-up to find real root)
 	workspaceInfo, err := t.workspaceManager.DetectWorkspace(params)
 	if err != nil {
 		return "", fmt.Errorf("failed to detect workspace: %w", err)
+	}
+
+	// Register workspace so other tools can resolve it without path detection
+	if reg := t.workspaceManager.GetRegistry(); reg != nil {
+		if err := reg.Register(workspaceInfo); err != nil {
+			log.Printf("⚠️ Failed to register workspace: %v", err)
+		}
 	}
 
 	// Optional: allow specifying specific language to index

--- a/internal/tools/install_skill.go
+++ b/internal/tools/install_skill.go
@@ -8,6 +8,11 @@ import (
 	"github.com/doITmagic/rag-code-mcp/internal/workspace"
 )
 
+var (
+	installSkillFunc   = skills.InstallSkill
+	uninstallSkillFunc = skills.UninstallSkill
+)
+
 type InstallSkillTool struct {
 	workspaceManager *workspace.Manager
 }
@@ -53,13 +58,13 @@ func (t *InstallSkillTool) Execute(ctx context.Context, args map[string]interfac
 	workspaceRoot := workspaceInfo.Root
 
 	if active {
-		err = skills.InstallSkill(skillID, workspaceRoot)
+		err = installSkillFunc(skillID, workspaceRoot)
 		if err != nil {
 			return "", fmt.Errorf("failed to install skill %s: %w", skillID, err)
 		}
 		return fmt.Sprintf("✅ Skill '%s' has been successfully installed in %s/.agent/skills/%s", skillID, workspaceRoot, skillID), nil
 	} else {
-		err = skills.UninstallSkill(skillID, workspaceRoot)
+		err = uninstallSkillFunc(skillID, workspaceRoot)
 		if err != nil {
 			return "", fmt.Errorf("failed to uninstall skill %s: %w", skillID, err)
 		}

--- a/internal/tools/install_skill.go
+++ b/internal/tools/install_skill.go
@@ -25,7 +25,7 @@ func (t *InstallSkillTool) Name() string {
 func (t *InstallSkillTool) Description() string {
 	return `Installs or uninstalls an AI skill to/from the current workspace. 
 Param 'skill_id' is the unique identifier of the skill (e.g., 'go-best-practices', 'ragcode-priority').
-Param 'active' (bool) determines if it should be installed (true) or removed (false).
+Param 'active' (bool) determines if it should be installed (true) or removed (false). This flag is MANDATORY; omitting it will return an error even for installs.
 Param 'file_path' (string) is HIGHLY RECOMMENDED to help detect the correct workspace root.
 
 EXAMPLES:
@@ -44,12 +44,10 @@ func (t *InstallSkillTool) Execute(ctx context.Context, args map[string]interfac
 		return "", fmt.Errorf("parameter 'skill_id' is required")
 	}
 
-	// Detect workspace to know where to install the skill
-	workspaceInfo, err := t.workspaceManager.DetectWorkspace(args)
+	// Resolve workspace from registry
+	workspaceInfo, err := t.workspaceManager.ResolveWorkspace(args)
 	if err != nil {
-		return "", fmt.Errorf("could not detect workspace for skill installation: %w\n\n"+
-			"TIP: If automatic detection fails, please provide an explicit 'file_path' or 'workspace_root' "+
-			"to a directory in your project containing workspace markers (like .git, go.mod, package.json).", err)
+		return "", fmt.Errorf("could not resolve workspace for skill installation: %w", err)
 	}
 
 	workspaceRoot := workspaceInfo.Root

--- a/internal/tools/list_package_exports.go
+++ b/internal/tools/list_package_exports.go
@@ -63,12 +63,8 @@ func (t *ListPackageExportsTool) Execute(ctx context.Context, args map[string]in
 		outputFormat = strings.ToLower(of)
 	}
 
-	// file_path with single-workspace fallback
-	filePath, err := resolveFilePathWithFallback(args, t.workspaceManager, "list_package_exports")
-	if err != nil {
-		return "", err
-	}
-	_ = filePath
+	// file_path with single-workspace fallback (no error - defers to DetectWorkspace)
+	resolveFilePathWithFallback(args, t.workspaceManager, "list_package_exports")
 
 	// Try workspace detection if workspace manager is available
 	var searchMemory memory.LongTermMemory
@@ -81,7 +77,7 @@ func (t *ListPackageExportsTool) Execute(ctx context.Context, args map[string]in
 			workspaceInfo = wi
 
 			// Detect language from file path or use first detected language
-			language := inferLanguageFromPath(filePath)
+			language := inferLanguageFromPath(extractFilePathFromParams(args))
 			if language == "" && len(wi.Languages) > 0 {
 				language = wi.Languages[0]
 			}

--- a/internal/tools/list_package_exports.go
+++ b/internal/tools/list_package_exports.go
@@ -63,52 +63,44 @@ func (t *ListPackageExportsTool) Execute(ctx context.Context, args map[string]in
 		outputFormat = strings.ToLower(of)
 	}
 
-	// file_path with single-workspace fallback (no error - defers to DetectWorkspace)
-	resolveFilePathWithFallback(args, t.workspaceManager, "list_package_exports")
-
-	// Try workspace detection if workspace manager is available
+	// Resolve workspace from registry
 	var searchMemory memory.LongTermMemory
 	var workspaceInfo *workspace.Info
 	var collectionName string
 
 	if t.workspaceManager != nil {
-		wi, err := t.workspaceManager.DetectWorkspace(args)
-		if err == nil && wi != nil {
-			workspaceInfo = wi
+		wi, err := t.workspaceManager.ResolveWorkspace(args)
+		if err != nil {
+			return "", err
+		}
+		workspaceInfo = wi
 
-			// Detect language from file path or use first detected language
-			language := inferLanguageFromPath(extractFilePathFromParams(args))
-			if language == "" && len(wi.Languages) > 0 {
-				language = wi.Languages[0]
-			}
-			if language == "" {
-				language = wi.ProjectType
+		language := ""
+		if len(wi.Languages) > 0 {
+			language = wi.Languages[0]
+		}
+
+		collectionName = wi.CollectionNameForLanguage(language)
+		mem, err := t.workspaceManager.GetMemoryForWorkspaceLanguage(ctx, wi, language)
+		if err == nil && mem != nil {
+			indexKey := wi.ID + "-" + language
+			if t.workspaceManager.IsIndexing(indexKey) {
+				return fmt.Sprintf("⏳ Workspace '%s' language '%s' is currently being indexed in the background.\n"+
+					"Please try again in a few moments.\n"+
+					"Workspace: %s\n"+
+					"Language: %s\n"+
+					"Collection: %s",
+					wi.Root, language, wi.Root, language, collectionName), nil
 			}
 
-			collectionName = wi.CollectionNameForLanguage(language)
-			mem, err := t.workspaceManager.GetMemoryForWorkspaceLanguage(ctx, wi, language)
-			if err == nil && mem != nil {
-				// Check if indexing is in progress
-				indexKey := wi.ID + "-" + language
-				if t.workspaceManager.IsIndexing(indexKey) {
-					return fmt.Sprintf("⏳ Workspace '%s' language '%s' is currently being indexed in the background.\n"+
-						"Please try again in a few moments.\n"+
-						"Workspace: %s\n"+
-						"Language: %s\n"+
-						"Collection: %s",
-						wi.Root, language, wi.Root, language, collectionName), nil
+			if msg, err := CheckCollectionStatus(ctx, mem, collectionName, wi.Root); err != nil || msg != "" {
+				if err != nil {
+					return "", err
 				}
-
-				// Check if collection exists before proceeding
-				if msg, err := CheckCollectionStatus(ctx, mem, collectionName, wi.Root); err != nil || msg != "" {
-					if err != nil {
-						return "", err
-					}
-					return msg, nil
-				}
-
-				searchMemory = mem
+				return msg, nil
 			}
+
+			searchMemory = mem
 		}
 	}
 

--- a/internal/tools/list_package_exports.go
+++ b/internal/tools/list_package_exports.go
@@ -63,11 +63,12 @@ func (t *ListPackageExportsTool) Execute(ctx context.Context, args map[string]in
 		outputFormat = strings.ToLower(of)
 	}
 
-	// file_path is required for workspace detection
-	filePath := extractFilePathFromParams(args)
-	if filePath == "" {
-		return "", fmt.Errorf("file_path parameter is required for list_package_exports. Please provide a file path from your workspace")
+	// file_path with single-workspace fallback
+	filePath, err := resolveFilePathWithFallback(args, t.workspaceManager, "list_package_exports")
+	if err != nil {
+		return "", err
 	}
+	_ = filePath
 
 	// Try workspace detection if workspace manager is available
 	var searchMemory memory.LongTermMemory

--- a/internal/tools/list_skills.go
+++ b/internal/tools/list_skills.go
@@ -9,6 +9,11 @@ import (
 	"github.com/doITmagic/rag-code-mcp/internal/workspace"
 )
 
+var (
+	listAvailableSkillsFunc = skills.ListAvailableSkills
+	isSkillInstalledFunc    = skills.IsSkillInstalled
+)
+
 type ListSkillsTool struct {
 	workspaceManager *workspace.Manager
 }
@@ -28,7 +33,7 @@ func (t *ListSkillsTool) Description() string {
 }
 
 func (t *ListSkillsTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
-	available, err := skills.ListAvailableSkills()
+	available, err := listAvailableSkillsFunc()
 	if err != nil {
 		return "", fmt.Errorf("failed to list skills: %w", err)
 	}
@@ -56,7 +61,7 @@ func (t *ListSkillsTool) Execute(ctx context.Context, args map[string]interface{
 	for _, s := range available {
 		installed := false
 		if workspaceRoot != "" {
-			installed = skills.IsSkillInstalled(s.ID, workspaceRoot)
+			installed = isSkillInstalledFunc(s.ID, workspaceRoot)
 		}
 		extendedList = append(extendedList, SkillWithStatus{
 			SkillInfo: s,

--- a/internal/tools/list_skills.go
+++ b/internal/tools/list_skills.go
@@ -6,12 +6,17 @@ import (
 	"fmt"
 
 	"github.com/doITmagic/rag-code-mcp/internal/skills"
+	"github.com/doITmagic/rag-code-mcp/internal/workspace"
 )
 
-type ListSkillsTool struct{}
+type ListSkillsTool struct {
+	workspaceManager *workspace.Manager
+}
 
-func NewListSkillsTool() *ListSkillsTool {
-	return &ListSkillsTool{}
+func NewListSkillsTool(workspaceManager *workspace.Manager) *ListSkillsTool {
+	return &ListSkillsTool{
+		workspaceManager: workspaceManager,
+	}
 }
 
 func (t *ListSkillsTool) Name() string {
@@ -19,7 +24,7 @@ func (t *ListSkillsTool) Name() string {
 }
 
 func (t *ListSkillsTool) Description() string {
-	return "Lists all available AI skills bundled within the ragcode binary. These skills can be installed to help the AI better understand the project using ragcode tools."
+	return "Lists all available AI skills bundled within the ragcode binary. These skills can be installed to help the AI better understand the project using ragcode tools. Returns a list showing which skills are currently installed (active) in the detected workspace."
 }
 
 func (t *ListSkillsTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
@@ -32,10 +37,64 @@ func (t *ListSkillsTool) Execute(ctx context.Context, args map[string]interface{
 		return "No skills found in the binary.", nil
 	}
 
-	data, err := json.MarshalIndent(available, "", "  ")
+	// Try to detect workspace to check installation status
+	var workspaceRoot string
+	if t.workspaceManager != nil {
+		// Even if args are empty, try to detect from CWD or other means
+		// We pass the empty args to DetectWorkspace which has fallback logic
+		info, err := t.workspaceManager.DetectWorkspace(args)
+		if err == nil && info != nil {
+			workspaceRoot = info.Root
+		}
+	}
+
+	// Enrich the list with installation status
+	type SkillWithStatus struct {
+		skills.SkillInfo
+		Installed bool `json:"installed"`
+	}
+
+	var extendedList []SkillWithStatus
+	for _, s := range available {
+		installed := false
+		if workspaceRoot != "" {
+			installed = skills.IsSkillInstalled(s.ID, workspaceRoot)
+		}
+		extendedList = append(extendedList, SkillWithStatus{
+			SkillInfo: s,
+			Installed: installed,
+		})
+	}
+
+	data, err := json.MarshalIndent(extendedList, "", "  ")
 	if err != nil {
 		return "", fmt.Errorf("failed to format skills list: %w", err)
 	}
 
-	return string(data), nil
+	output := string(data)
+	if workspaceRoot != "" {
+		output = fmt.Sprintf("🌍 Detected Workspace: %s\n\n%s", workspaceRoot, output)
+	} else {
+		output = "⚠️  Warning: Could not detect active workspace. 'installed' status may be inaccurate.\nProvide 'file_path' argument to detect workspace.\n\n" + output
+	}
+
+	output += "\n\n---\n💡 Want to add your own skill?\n"
+	output += "Create a folder in .agent/skills/ (or define RAGCODE_SKILLS_PATH) with a SKILL.md file.\n"
+	output += "IMPORTANT: You MUST include 'compatible-with: [rag-code-mcp]' in the frontmatter!\n\n"
+	output += "Example SKILL.md:\n"
+	output += "```yaml\n"
+	output += "---\n"
+	output += "name: my-new-skill\n"
+	output += "description: Description of what this skill does\n"
+	output += "compatible-with: [rag-code-mcp]\n"
+	output += "---\n\n"
+	output += "# My New Skill\n"
+	output += "Instructions for the AI...\n"
+	output += "```"
+
+	return output, nil
+}
+
+func (t *ListSkillsTool) SetWorkspaceManager(m *workspace.Manager) {
+	t.workspaceManager = m
 }

--- a/internal/tools/list_skills.go
+++ b/internal/tools/list_skills.go
@@ -37,12 +37,10 @@ func (t *ListSkillsTool) Execute(ctx context.Context, args map[string]interface{
 		return "No skills found in the binary.", nil
 	}
 
-	// Try to detect workspace to check installation status
+	// Resolve workspace from registry to check installation status
 	var workspaceRoot string
 	if t.workspaceManager != nil {
-		// Even if args are empty, try to detect from CWD or other means
-		// We pass the empty args to DetectWorkspace which has fallback logic
-		info, err := t.workspaceManager.DetectWorkspace(args)
+		info, err := t.workspaceManager.ResolveWorkspace(args)
 		if err == nil && info != nil {
 			workspaceRoot = info.Root
 		}

--- a/internal/tools/search_docs.go
+++ b/internal/tools/search_docs.go
@@ -41,11 +41,12 @@ func (t *SearchDocsTool) Description() string {
 
 // Execute executes a search in the docs index
 func (t *SearchDocsTool) Execute(ctx context.Context, params map[string]interface{}) (string, error) {
-	// file_path is required for workspace detection
-	filePath := extractFilePathFromParams(params)
-	if filePath == "" {
-		return "", fmt.Errorf("file_path parameter is required for search_docs. Please provide a file path from your workspace")
+	// file_path with single-workspace fallback
+	filePath, err := resolveFilePathWithFallback(params, t.workspaceManager, "search_docs")
+	if err != nil {
+		return "", err
 	}
+	_ = filePath
 
 	// Try workspace detection
 	var searchMemory memory.LongTermMemory

--- a/internal/tools/search_docs.go
+++ b/internal/tools/search_docs.go
@@ -41,12 +41,8 @@ func (t *SearchDocsTool) Description() string {
 
 // Execute executes a search in the docs index
 func (t *SearchDocsTool) Execute(ctx context.Context, params map[string]interface{}) (string, error) {
-	// file_path with single-workspace fallback
-	filePath, err := resolveFilePathWithFallback(params, t.workspaceManager, "search_docs")
-	if err != nil {
-		return "", err
-	}
-	_ = filePath
+	// file_path with single-workspace fallback (no error - defers to DetectWorkspace)
+	resolveFilePathWithFallback(params, t.workspaceManager, "search_docs")
 
 	// Try workspace detection
 	var searchMemory memory.LongTermMemory
@@ -59,7 +55,7 @@ func (t *SearchDocsTool) Execute(ctx context.Context, params map[string]interfac
 			workspacePath = workspaceInfo.Root
 
 			// Detect language from file path or use first detected language
-			language := inferLanguageFromPath(filePath)
+			language := inferLanguageFromPath(extractFilePathFromParams(params))
 			if language == "" && len(workspaceInfo.Languages) > 0 {
 				language = workspaceInfo.Languages[0]
 			}

--- a/internal/tools/search_docs.go
+++ b/internal/tools/search_docs.go
@@ -41,52 +41,44 @@ func (t *SearchDocsTool) Description() string {
 
 // Execute executes a search in the docs index
 func (t *SearchDocsTool) Execute(ctx context.Context, params map[string]interface{}) (string, error) {
-	// file_path with single-workspace fallback (no error - defers to DetectWorkspace)
-	resolveFilePathWithFallback(params, t.workspaceManager, "search_docs")
-
-	// Try workspace detection
+	// Resolve workspace from registry
 	var searchMemory memory.LongTermMemory
 	var workspacePath string
 	var collectionName string
 
 	if t.workspaceManager != nil {
-		workspaceInfo, err := t.workspaceManager.DetectWorkspace(params)
-		if err == nil && workspaceInfo != nil {
-			workspacePath = workspaceInfo.Root
+		workspaceInfo, err := t.workspaceManager.ResolveWorkspace(params)
+		if err != nil {
+			return "", err
+		}
+		workspacePath = workspaceInfo.Root
 
-			// Detect language from file path or use first detected language
-			language := inferLanguageFromPath(extractFilePathFromParams(params))
-			if language == "" && len(workspaceInfo.Languages) > 0 {
-				language = workspaceInfo.Languages[0]
-			}
-			if language == "" {
-				language = workspaceInfo.ProjectType
+		language := ""
+		if len(workspaceInfo.Languages) > 0 {
+			language = workspaceInfo.Languages[0]
+		}
+
+		collectionName = workspaceInfo.CollectionNameForLanguage(language)
+		mem, err := t.workspaceManager.GetMemoryForWorkspaceLanguage(ctx, workspaceInfo, language)
+		if err == nil && mem != nil {
+			indexKey := workspaceInfo.ID + "-" + language
+			if t.workspaceManager.IsIndexing(indexKey) {
+				return fmt.Sprintf("⏳ Workspace '%s' language '%s' is currently being indexed in the background.\n"+
+					"Please try again in a few moments.\n"+
+					"Workspace: %s\n"+
+					"Language: %s\n"+
+					"Collection: %s",
+					workspaceInfo.Root, language, workspaceInfo.Root, language, collectionName), nil
 			}
 
-			collectionName = workspaceInfo.CollectionNameForLanguage(language)
-			mem, err := t.workspaceManager.GetMemoryForWorkspaceLanguage(ctx, workspaceInfo, language)
-			if err == nil && mem != nil {
-				// Check if indexing is in progress
-				indexKey := workspaceInfo.ID + "-" + language
-				if t.workspaceManager.IsIndexing(indexKey) {
-					return fmt.Sprintf("⏳ Workspace '%s' language '%s' is currently being indexed in the background.\n"+
-						"Please try again in a few moments.\n"+
-						"Workspace: %s\n"+
-						"Language: %s\n"+
-						"Collection: %s",
-						workspaceInfo.Root, language, workspaceInfo.Root, language, collectionName), nil
+			if msg, err := CheckCollectionStatus(ctx, mem, collectionName, workspacePath); err != nil || msg != "" {
+				if err != nil {
+					return "", err
 				}
-
-				// Check if collection exists before proceeding
-				if msg, err := CheckCollectionStatus(ctx, mem, collectionName, workspacePath); err != nil || msg != "" {
-					if err != nil {
-						return "", err
-					}
-					return msg, nil
-				}
-
-				searchMemory = mem
+				return msg, nil
 			}
+
+			searchMemory = mem
 		}
 	}
 

--- a/internal/tools/search_local_index.go
+++ b/internal/tools/search_local_index.go
@@ -72,11 +72,12 @@ func (t *SearchLocalIndexTool) Execute(ctx context.Context, params map[string]in
 		return "", fmt.Errorf("failed to generate query embedding: %w", err)
 	}
 
-	// file_path is required for workspace detection
-	filePath := extractFilePathFromParams(params)
-	if filePath == "" {
-		return "", fmt.Errorf("file_path parameter is required for search_code. Please provide a file path from your workspace")
+	// file_path with single-workspace fallback
+	filePath, err := resolveFilePathWithFallback(params, t.workspaceManager, "search_code")
+	if err != nil {
+		return "", err
 	}
+	_ = filePath
 
 	// Try workspace-aware search first
 	if t.workspaceManager != nil {

--- a/internal/tools/search_local_index.go
+++ b/internal/tools/search_local_index.go
@@ -72,34 +72,16 @@ func (t *SearchLocalIndexTool) Execute(ctx context.Context, params map[string]in
 		return "", fmt.Errorf("failed to generate query embedding: %w", err)
 	}
 
-	// file_path with single-workspace fallback (no error - defers to DetectWorkspace)
-	resolveFilePathWithFallback(params, t.workspaceManager, "search_code")
-
-	// Try workspace-aware search first
+	// Resolve workspace from registry
 	if t.workspaceManager != nil {
-		workspaceInfo, err := t.workspaceManager.DetectWorkspace(params)
+		workspaceInfo, err := t.workspaceManager.ResolveWorkspace(params)
 		if err != nil {
-			// Workspace detection failed - return helpful message
-			return fmt.Sprintf("❌ Could not detect workspace from the provided file path.\n\n"+
-				"To enable workspace-aware code search, please provide a valid file_path parameter "+
-				"pointing to a file within your workspace.\n\n"+
-				"Error: %v", err), nil
+			return "", err
 		}
 
-		// Detect language from file path or query context
 		language := ""
-		if filePath := extractFilePathFromParams(params); filePath != "" {
-			language = inferLanguageFromPath(filePath)
-		}
-
-		// If no language detected from path, use first detected language in workspace
-		if language == "" && len(workspaceInfo.Languages) > 0 {
+		if len(workspaceInfo.Languages) > 0 {
 			language = workspaceInfo.Languages[0]
-		}
-
-		// Fallback to ProjectType
-		if language == "" {
-			language = workspaceInfo.ProjectType
 		}
 
 		// Get workspace-specific memory for the detected language

--- a/internal/tools/search_local_index.go
+++ b/internal/tools/search_local_index.go
@@ -72,12 +72,8 @@ func (t *SearchLocalIndexTool) Execute(ctx context.Context, params map[string]in
 		return "", fmt.Errorf("failed to generate query embedding: %w", err)
 	}
 
-	// file_path with single-workspace fallback
-	filePath, err := resolveFilePathWithFallback(params, t.workspaceManager, "search_code")
-	if err != nil {
-		return "", err
-	}
-	_ = filePath
+	// file_path with single-workspace fallback (no error - defers to DetectWorkspace)
+	resolveFilePathWithFallback(params, t.workspaceManager, "search_code")
 
 	// Try workspace-aware search first
 	if t.workspaceManager != nil {

--- a/internal/tools/skills_tools_test.go
+++ b/internal/tools/skills_tools_test.go
@@ -1,0 +1,149 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/doITmagic/rag-code-mcp/internal/skills"
+	"github.com/doITmagic/rag-code-mcp/internal/workspace"
+)
+
+func restoreSkillToolStubs() func() {
+	origInstall := installSkillFunc
+	origUninstall := uninstallSkillFunc
+	origList := listAvailableSkillsFunc
+	origIsInstalled := isSkillInstalledFunc
+	return func() {
+		installSkillFunc = origInstall
+		uninstallSkillFunc = origUninstall
+		listAvailableSkillsFunc = origList
+		isSkillInstalledFunc = origIsInstalled
+	}
+}
+
+func newTestWorkspaceManager(t *testing.T) (*workspace.Manager, *workspace.Info) {
+	t.Helper()
+	regDir := t.TempDir()
+	cache := workspace.NewCache(time.Minute)
+	mgr := workspace.NewManagerForTest(cache, regDir)
+	info := &workspace.Info{Root: regDir, ID: "ws-test"}
+	if err := mgr.GetRegistry().Register(info); err != nil {
+		t.Fatalf("failed to register test workspace: %v", err)
+	}
+	return mgr, info
+}
+
+func TestInstallSkillTool_InstallSuccess(t *testing.T) {
+	defer restoreSkillToolStubs()()
+	mgr, info := newTestWorkspaceManager(t)
+
+	var called bool
+	installSkillFunc = func(skillID string, root string) error {
+		called = true
+		if skillID != "go-best-practices" {
+			t.Fatalf("unexpected skill id %s", skillID)
+		}
+		if root != info.Root {
+			t.Fatalf("unexpected root %s", root)
+		}
+		return nil
+	}
+
+	tool := NewInstallSkillTool(mgr)
+	msg, err := tool.Execute(context.Background(), map[string]interface{}{
+		"skill_id": "go-best-practices",
+		"active":   true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatalf("expected installSkillFunc to be invoked")
+	}
+	if !strings.Contains(msg, "successfully installed") {
+		t.Fatalf("unexpected success message: %s", msg)
+	}
+}
+
+func TestInstallSkillTool_UninstallError(t *testing.T) {
+	defer restoreSkillToolStubs()()
+	mgr, _ := newTestWorkspaceManager(t)
+
+	uninstallSkillFunc = func(skillID string, root string) error {
+		return errors.New("oops")
+	}
+
+	tool := NewInstallSkillTool(mgr)
+	_, err := tool.Execute(context.Background(), map[string]interface{}{
+		"skill_id": "ragcode-priority",
+		"active":   false,
+	})
+	if err == nil || !strings.Contains(err.Error(), "failed to uninstall") {
+		t.Fatalf("expected uninstall error, got %v", err)
+	}
+}
+
+func TestInstallSkillTool_WorkspaceResolveError(t *testing.T) {
+	defer restoreSkillToolStubs()()
+	cache := workspace.NewCache(time.Minute)
+	mgr := workspace.NewManagerForTest(cache, "") // empty registry
+
+	tool := NewInstallSkillTool(mgr)
+	_, err := tool.Execute(context.Background(), map[string]interface{}{
+		"skill_id": "anything",
+		"active":   true,
+	})
+	if err == nil {
+		t.Fatalf("expected workspace resolution error")
+	}
+}
+
+func TestListSkillsTool_WithWorkspace(t *testing.T) {
+	defer restoreSkillToolStubs()()
+	mgr, info := newTestWorkspaceManager(t)
+
+	listAvailableSkillsFunc = func() ([]skills.SkillInfo, error) {
+		return []skills.SkillInfo{
+			{ID: "skill-a", Name: "Skill A"},
+			{ID: "skill-b", Name: "Skill B"},
+		}, nil
+	}
+	isSkillInstalledFunc = func(skillID, root string) bool {
+		if root != info.Root {
+			t.Fatalf("unexpected root passed to isSkillInstalled")
+		}
+		return skillID == "skill-a"
+	}
+
+	tool := NewListSkillsTool(mgr)
+	out, err := tool.Execute(context.Background(), map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "Detected Workspace") {
+		t.Fatalf("expected workspace header, got %s", out)
+	}
+	if !strings.Contains(out, "\"skill-a\"") || !strings.Contains(out, "\"skill-b\"") {
+		t.Fatalf("output missing skills: %s", out)
+	}
+	if !strings.Contains(out, "\"installed\": true") || !strings.Contains(out, "\"installed\": false") {
+		t.Fatalf("output missing installed statuses: %s", out)
+	}
+}
+
+func TestListSkillsTool_ListError(t *testing.T) {
+	defer restoreSkillToolStubs()()
+	mgr, _ := newTestWorkspaceManager(t)
+
+	listAvailableSkillsFunc = func() ([]skills.SkillInfo, error) {
+		return nil, errors.New("fail list")
+	}
+
+	tool := NewListSkillsTool(mgr)
+	if _, err := tool.Execute(context.Background(), nil); err == nil {
+		t.Fatalf("expected error from list skills")
+	}
+}

--- a/internal/tools/updates.go
+++ b/internal/tools/updates.go
@@ -9,6 +9,14 @@ import (
 	"github.com/doITmagic/rag-code-mcp/internal/updater"
 )
 
+var (
+	checkForUpdates   = updater.CheckForUpdates
+	applyUpdateFunc   = updater.ApplyUpdate
+	downloadAndVerify = func(info *updater.UpdateInfo, ctx context.Context, dest string) error {
+		return info.DownloadAndVerify(ctx, dest)
+	}
+)
+
 type CheckUpdateTool struct {
 	version string
 }
@@ -27,7 +35,7 @@ func (t *CheckUpdateTool) Execute(ctx context.Context, args map[string]interface
 	if f, ok := args["force"].(bool); ok {
 		force = f
 	}
-	info, err := updater.CheckForUpdates(ctx, t.version, force)
+	info, err := checkForUpdates(ctx, t.version, force)
 	if err != nil {
 		return "", fmt.Errorf("failed to check for updates: %w", err)
 	}
@@ -58,7 +66,7 @@ func (t *ApplyUpdateTool) Execute(ctx context.Context, args map[string]interface
 		force = f
 	}
 
-	info, err := updater.CheckForUpdates(ctx, t.version, force)
+	info, err := checkForUpdates(ctx, t.version, force)
 	if err != nil {
 		return "", err
 	}
@@ -84,11 +92,11 @@ func (t *ApplyUpdateTool) Execute(ctx context.Context, args map[string]interface
 	}
 	defer os.Remove(tempPath)
 
-	if err := info.DownloadAndVerify(ctx, tempPath); err != nil {
+	if err := downloadAndVerify(info, ctx, tempPath); err != nil {
 		return "", fmt.Errorf("failed to download update: %w", err)
 	}
 
-	if err := updater.ApplyUpdate(tempPath); err != nil {
+	if err := applyUpdateFunc(tempPath); err != nil {
 		return "", fmt.Errorf("failed to install update: %w", err)
 	}
 

--- a/internal/tools/updates_test.go
+++ b/internal/tools/updates_test.go
@@ -1,0 +1,162 @@
+package tools
+
+import (
+    "context"
+    "errors"
+    "strings"
+    "testing"
+
+    "github.com/doITmagic/rag-code-mcp/internal/updater"
+)
+
+func restoreUpdateStubs() func() {
+    origCheck := checkForUpdates
+    origDownload := downloadAndVerify
+    origApply := applyUpdateFunc
+    return func() {
+        checkForUpdates = origCheck
+        downloadAndVerify = origDownload
+        applyUpdateFunc = origApply
+    }
+}
+
+func TestCheckUpdateTool_NoUpdates(t *testing.T) {
+    defer restoreUpdateStubs()()
+    forced := false
+    checkForUpdates = func(ctx context.Context, version string, force bool) (*updater.UpdateInfo, error) {
+        forced = force
+        return nil, nil
+    }
+
+    tool := NewCheckUpdateTool("1.0.0")
+    msg, err := tool.Execute(context.Background(), map[string]interface{}{})
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if !strings.Contains(msg, "latest version (1.0.0)") {
+        t.Fatalf("unexpected message: %s", msg)
+    }
+    if forced {
+        t.Fatalf("expected force=false, got true")
+    }
+}
+
+func TestCheckUpdateTool_WithUpdate(t *testing.T) {
+    defer restoreUpdateStubs()()
+    checkForUpdates = func(ctx context.Context, version string, force bool) (*updater.UpdateInfo, error) {
+        return &updater.UpdateInfo{LatestVersion: "2.0.0"}, nil
+    }
+
+    tool := NewCheckUpdateTool("1.0.0")
+    msg, err := tool.Execute(context.Background(), map[string]interface{}{"force": true})
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if !strings.Contains(msg, "2.0.0") {
+        t.Fatalf("expected message to mention newer version, got %s", msg)
+    }
+}
+
+func TestCheckUpdateTool_Error(t *testing.T) {
+    defer restoreUpdateStubs()()
+    checkForUpdates = func(ctx context.Context, version string, force bool) (*updater.UpdateInfo, error) {
+        return nil, errors.New("boom")
+    }
+
+    tool := NewCheckUpdateTool("1.0.0")
+    if _, err := tool.Execute(context.Background(), nil); err == nil {
+        t.Fatalf("expected error")
+    }
+}
+
+func TestApplyUpdateTool_NoUpdate(t *testing.T) {
+    defer restoreUpdateStubs()()
+    forced := false
+    checkForUpdates = func(ctx context.Context, version string, force bool) (*updater.UpdateInfo, error) {
+        forced = force
+        return nil, nil
+    }
+
+    tool := NewApplyUpdateTool("1.0.0")
+    msg, err := tool.Execute(context.Background(), map[string]interface{}{})
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if !strings.Contains(msg, "latest version") {
+        t.Fatalf("unexpected message: %s", msg)
+    }
+    if !forced {
+        t.Fatalf("expected force=true by default for apply_update")
+    }
+}
+
+func TestApplyUpdateTool_Success(t *testing.T) {
+    defer restoreUpdateStubs()()
+    var downloadCalled, applyCalled bool
+    var capturedPath string
+
+    info := &updater.UpdateInfo{LatestVersion: "2.0.0", AssetURL: "foo.tar.gz"}
+    checkForUpdates = func(ctx context.Context, version string, force bool) (*updater.UpdateInfo, error) {
+        return info, nil
+    }
+    downloadAndVerify = func(gotInfo *updater.UpdateInfo, ctx context.Context, dest string) error {
+        downloadCalled = true
+        if gotInfo != info {
+            t.Fatalf("download received unexpected info pointer")
+        }
+        capturedPath = dest
+        return nil
+    }
+    applyUpdateFunc = func(path string) error {
+        applyCalled = true
+        if path != capturedPath {
+            t.Fatalf("apply called with %s, want %s", path, capturedPath)
+        }
+        return nil
+    }
+
+    tool := NewApplyUpdateTool("1.0.0")
+    msg, err := tool.Execute(context.Background(), nil)
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if !downloadCalled || !applyCalled {
+        t.Fatalf("expected download and apply to be called")
+    }
+    if !strings.Contains(msg, "2.0.0") {
+        t.Fatalf("expected success message to mention new version")
+    }
+}
+
+func TestApplyUpdateTool_DownloadError(t *testing.T) {
+    defer restoreUpdateStubs()()
+    checkForUpdates = func(ctx context.Context, version string, force bool) (*updater.UpdateInfo, error) {
+        return &updater.UpdateInfo{LatestVersion: "2.0.0", AssetURL: "foo.tar.gz"}, nil
+    }
+    downloadAndVerify = func(info *updater.UpdateInfo, ctx context.Context, dest string) error {
+        return errors.New("download failed")
+    }
+
+    tool := NewApplyUpdateTool("1.0.0")
+    if _, err := tool.Execute(context.Background(), nil); err == nil {
+        t.Fatalf("expected error when download fails")
+    }
+}
+
+func TestApplyUpdateTool_ApplyError(t *testing.T) {
+    defer restoreUpdateStubs()()
+    checkForUpdates = func(ctx context.Context, version string, force bool) (*updater.UpdateInfo, error) {
+        return &updater.UpdateInfo{LatestVersion: "2.0.0", AssetURL: "foo.tar.gz"}, nil
+    }
+    downloadAndVerify = func(info *updater.UpdateInfo, ctx context.Context, dest string) error {
+        return nil
+    }
+    applyUpdateFunc = func(path string) error {
+        return errors.New("apply failed")
+    }
+
+    tool := NewApplyUpdateTool("1.0.0")
+    if _, err := tool.Execute(context.Background(), nil); err == nil {
+        t.Fatalf("expected error when apply fails")
+    }
+}

--- a/internal/tools/utils.go
+++ b/internal/tools/utils.go
@@ -3,14 +3,12 @@ package tools
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/doITmagic/rag-code-mcp/internal/codetypes"
 	"github.com/doITmagic/rag-code-mcp/internal/memory"
-	"github.com/doITmagic/rag-code-mcp/internal/workspace"
 )
 
 // readFileLines reads specific lines from a file
@@ -118,51 +116,4 @@ func inferLanguageFromPath(filePath string) string {
 	default:
 		return ""
 	}
-}
-
-// extractFilePathFromParams extracts file path from common parameter names
-func extractFilePathFromParams(params map[string]interface{}) string {
-	pathParams := []string{
-		"file_path",
-		"filePath",
-		"path",
-		"file",
-		"source_file",
-		"target_file",
-	}
-
-	for _, param := range pathParams {
-		if value, ok := params[param]; ok {
-			if path, ok := value.(string); ok && path != "" {
-				return path
-			}
-		}
-	}
-
-	return ""
-}
-
-// resolveFilePathWithFallback extracts file_path from params, falling back to
-// the single active workspace root when only one workspace is indexed.
-// If file_path is resolved via fallback, it is injected into params so that
-// downstream DetectWorkspace calls work transparently.
-// Returns empty string (no error) when no fallback is available, allowing
-// DetectWorkspace/DetectFromParams to use its own CWD fallback.
-func resolveFilePathWithFallback(params map[string]interface{}, wm *workspace.Manager, toolName string) string {
-	filePath := extractFilePathFromParams(params)
-	if filePath != "" {
-		return filePath
-	}
-
-	// Fallback: if exactly one workspace is cached, use its root
-	if wm != nil {
-		if root := wm.GetSingleWorkspaceRoot(); root != "" {
-			log.Printf("[%s] file_path not provided, using single workspace fallback: %s", toolName, root)
-			params["file_path"] = root
-			return root
-		}
-	}
-
-	log.Printf("[%s] file_path not provided and no single workspace fallback available, deferring to DetectWorkspace", toolName)
-	return ""
 }

--- a/internal/tools/utils.go
+++ b/internal/tools/utils.go
@@ -3,12 +3,14 @@ package tools
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/doITmagic/rag-code-mcp/internal/codetypes"
 	"github.com/doITmagic/rag-code-mcp/internal/memory"
+	"github.com/doITmagic/rag-code-mcp/internal/workspace"
 )
 
 // readFileLines reads specific lines from a file
@@ -138,4 +140,26 @@ func extractFilePathFromParams(params map[string]interface{}) string {
 	}
 
 	return ""
+}
+
+// resolveFilePathWithFallback extracts file_path from params, falling back to
+// the single active workspace root when only one workspace is indexed.
+// If file_path is resolved via fallback, it is injected into params so that
+// downstream DetectWorkspace calls work transparently.
+func resolveFilePathWithFallback(params map[string]interface{}, wm *workspace.Manager, toolName string) (string, error) {
+	filePath := extractFilePathFromParams(params)
+	if filePath != "" {
+		return filePath, nil
+	}
+
+	// Fallback: if exactly one workspace is cached, use its root
+	if wm != nil {
+		if root := wm.GetSingleWorkspaceRoot(); root != "" {
+			log.Printf("[%s] file_path not provided, using single workspace fallback: %s", toolName, root)
+			params["file_path"] = root
+			return root, nil
+		}
+	}
+
+	return "", fmt.Errorf("file_path parameter is required for %s. Please provide a file path from your workspace", toolName)
 }

--- a/internal/tools/utils.go
+++ b/internal/tools/utils.go
@@ -146,10 +146,12 @@ func extractFilePathFromParams(params map[string]interface{}) string {
 // the single active workspace root when only one workspace is indexed.
 // If file_path is resolved via fallback, it is injected into params so that
 // downstream DetectWorkspace calls work transparently.
-func resolveFilePathWithFallback(params map[string]interface{}, wm *workspace.Manager, toolName string) (string, error) {
+// Returns empty string (no error) when no fallback is available, allowing
+// DetectWorkspace/DetectFromParams to use its own CWD fallback.
+func resolveFilePathWithFallback(params map[string]interface{}, wm *workspace.Manager, toolName string) string {
 	filePath := extractFilePathFromParams(params)
 	if filePath != "" {
-		return filePath, nil
+		return filePath
 	}
 
 	// Fallback: if exactly one workspace is cached, use its root
@@ -157,9 +159,10 @@ func resolveFilePathWithFallback(params map[string]interface{}, wm *workspace.Ma
 		if root := wm.GetSingleWorkspaceRoot(); root != "" {
 			log.Printf("[%s] file_path not provided, using single workspace fallback: %s", toolName, root)
 			params["file_path"] = root
-			return root, nil
+			return root
 		}
 	}
 
-	return "", fmt.Errorf("file_path parameter is required for %s. Please provide a file path from your workspace", toolName)
+	log.Printf("[%s] file_path not provided and no single workspace fallback available, deferring to DetectWorkspace", toolName)
+	return ""
 }

--- a/internal/tools/utils_test.go
+++ b/internal/tools/utils_test.go
@@ -1,0 +1,195 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/doITmagic/rag-code-mcp/internal/workspace"
+)
+
+func TestExtractFilePathFromParams(t *testing.T) {
+	tests := []struct {
+		name     string
+		params   map[string]interface{}
+		expected string
+	}{
+		{
+			name:     "empty params",
+			params:   map[string]interface{}{},
+			expected: "",
+		},
+		{
+			name:     "file_path present",
+			params:   map[string]interface{}{"file_path": "/home/user/project/main.go"},
+			expected: "/home/user/project/main.go",
+		},
+		{
+			name:     "filePath camelCase",
+			params:   map[string]interface{}{"filePath": "/home/user/project/main.go"},
+			expected: "/home/user/project/main.go",
+		},
+		{
+			name:     "path param",
+			params:   map[string]interface{}{"path": "/home/user/project/main.go"},
+			expected: "/home/user/project/main.go",
+		},
+		{
+			name:     "empty string value",
+			params:   map[string]interface{}{"file_path": ""},
+			expected: "",
+		},
+		{
+			name:     "non-string value",
+			params:   map[string]interface{}{"file_path": 123},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractFilePathFromParams(tt.params)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestResolveFilePathWithFallback_ExplicitPath(t *testing.T) {
+	params := map[string]interface{}{"file_path": "/home/user/project/main.go"}
+	result := resolveFilePathWithFallback(params, nil, "test_tool")
+	if result != "/home/user/project/main.go" {
+		t.Fatalf("expected explicit path, got %q", result)
+	}
+}
+
+func TestResolveFilePathWithFallback_NilManager(t *testing.T) {
+	params := map[string]interface{}{}
+	result := resolveFilePathWithFallback(params, nil, "test_tool")
+	if result != "" {
+		t.Fatalf("expected empty string with nil manager, got %q", result)
+	}
+}
+
+func TestResolveFilePathWithFallback_SingleWorkspaceFallback(t *testing.T) {
+	// Create a real workspace manager with a cache containing one workspace
+	cache := workspace.NewCache(5 * time.Minute)
+	cache.Set("/home/user/project/main.go", &workspace.Info{Root: "/home/user/project"})
+
+	mgr := workspace.NewManagerForTest(cache)
+
+	params := map[string]interface{}{}
+	result := resolveFilePathWithFallback(params, mgr, "test_tool")
+
+	if result != "/home/user/project" {
+		t.Fatalf("expected fallback to /home/user/project, got %q", result)
+	}
+
+	// Verify file_path was injected into params
+	if params["file_path"] != "/home/user/project" {
+		t.Fatalf("expected file_path injected into params, got %v", params["file_path"])
+	}
+}
+
+func TestResolveFilePathWithFallback_MultipleWorkspaces_ReturnsEmpty(t *testing.T) {
+	cache := workspace.NewCache(5 * time.Minute)
+	cache.Set("/home/user/project-a/main.go", &workspace.Info{Root: "/home/user/project-a"})
+	cache.Set("/home/user/project-b/main.go", &workspace.Info{Root: "/home/user/project-b"})
+
+	mgr := workspace.NewManagerForTest(cache)
+
+	params := map[string]interface{}{}
+	result := resolveFilePathWithFallback(params, mgr, "test_tool")
+
+	if result != "" {
+		t.Fatalf("expected empty string for multiple workspaces, got %q", result)
+	}
+
+	// Verify file_path was NOT injected
+	if _, ok := params["file_path"]; ok {
+		t.Fatalf("file_path should not be injected when multiple workspaces exist")
+	}
+}
+
+func TestResolveFilePathWithFallback_EmptyCache_ReturnsEmpty(t *testing.T) {
+	cache := workspace.NewCache(5 * time.Minute)
+	mgr := workspace.NewManagerForTest(cache)
+
+	params := map[string]interface{}{}
+	result := resolveFilePathWithFallback(params, mgr, "test_tool")
+
+	if result != "" {
+		t.Fatalf("expected empty string for empty cache, got %q", result)
+	}
+}
+
+func TestResolveFilePathWithFallback_ExplicitPathTakesPriority(t *testing.T) {
+	cache := workspace.NewCache(5 * time.Minute)
+	cache.Set("/home/user/cached-project/main.go", &workspace.Info{Root: "/home/user/cached-project"})
+
+	mgr := workspace.NewManagerForTest(cache)
+
+	params := map[string]interface{}{"file_path": "/home/user/explicit-project/main.go"}
+	result := resolveFilePathWithFallback(params, mgr, "test_tool")
+
+	if result != "/home/user/explicit-project/main.go" {
+		t.Fatalf("expected explicit path to take priority, got %q", result)
+	}
+}
+
+// TestEndToEnd_DetectWorkspace_WithoutFilePath tests the full flow:
+// resolveFilePathWithFallback returns "" → DetectWorkspace → DetectFromParams → CWD fallback
+func TestEndToEnd_DetectWorkspace_WithoutFilePath(t *testing.T) {
+	// Create a temporary workspace with a marker
+	tmpDir := t.TempDir()
+	workspaceDir := filepath.Join(tmpDir, "test-project")
+	if err := os.MkdirAll(workspaceDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspaceDir, "go.mod"), []byte("module test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create detector with allowed paths
+	detector := workspace.NewDetector()
+	detector.SetAllowedPaths([]string{tmpDir})
+
+	// Test DetectFromParams with empty params (will use CWD fallback)
+	// Note: CWD fallback may not point to our test workspace, but the important thing
+	// is that it doesn't panic or return a hard error about missing file_path
+	params := map[string]interface{}{}
+
+	// resolveFilePathWithFallback should return "" without error
+	result := resolveFilePathWithFallback(params, nil, "test_tool")
+	if result != "" {
+		t.Fatalf("expected empty string, got %q", result)
+	}
+
+	// DetectFromParams should still work (uses CWD fallback)
+	// We can't guarantee CWD is in our test workspace, but it should not panic
+	_, err := detector.DetectFromParams(params)
+	// Error is acceptable here (CWD may not be a valid workspace), but it should
+	// be a workspace detection error, not a "file_path required" error
+	if err != nil {
+		if contains(err.Error(), "file_path parameter is required") {
+			t.Fatalf("should not get 'file_path required' error, got: %v", err)
+		}
+		// Other errors (like CWD not being a valid workspace) are fine
+		t.Logf("DetectFromParams with empty params returned expected error: %v", err)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tools/utils_test.go
+++ b/internal/tools/utils_test.go
@@ -1,195 +1,39 @@
 package tools
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
-	"time"
-
-	"github.com/doITmagic/rag-code-mcp/internal/workspace"
 )
 
-func TestExtractFilePathFromParams(t *testing.T) {
+func TestInferLanguageFromPath(t *testing.T) {
 	tests := []struct {
-		name     string
-		params   map[string]interface{}
+		path     string
 		expected string
 	}{
-		{
-			name:     "empty params",
-			params:   map[string]interface{}{},
-			expected: "",
-		},
-		{
-			name:     "file_path present",
-			params:   map[string]interface{}{"file_path": "/home/user/project/main.go"},
-			expected: "/home/user/project/main.go",
-		},
-		{
-			name:     "filePath camelCase",
-			params:   map[string]interface{}{"filePath": "/home/user/project/main.go"},
-			expected: "/home/user/project/main.go",
-		},
-		{
-			name:     "path param",
-			params:   map[string]interface{}{"path": "/home/user/project/main.go"},
-			expected: "/home/user/project/main.go",
-		},
-		{
-			name:     "empty string value",
-			params:   map[string]interface{}{"file_path": ""},
-			expected: "",
-		},
-		{
-			name:     "non-string value",
-			params:   map[string]interface{}{"file_path": 123},
-			expected: "",
-		},
+		{"/home/user/main.go", "go"},
+		{"/home/user/app.py", "python"},
+		{"/home/user/index.js", "javascript"},
+		{"/home/user/index.ts", "javascript"},
+		{"/home/user/app.php", "php"},
+		{"/home/user/page.html", "html"},
+		{"/home/user/README.md", ""},
+		{"", ""},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := extractFilePathFromParams(tt.params)
+		t.Run(tt.path, func(t *testing.T) {
+			result := inferLanguageFromPath(tt.path)
 			if result != tt.expected {
-				t.Errorf("expected %q, got %q", tt.expected, result)
+				t.Errorf("inferLanguageFromPath(%q) = %q, want %q", tt.path, result, tt.expected)
 			}
 		})
 	}
 }
 
-func TestResolveFilePathWithFallback_ExplicitPath(t *testing.T) {
-	params := map[string]interface{}{"file_path": "/home/user/project/main.go"}
-	result := resolveFilePathWithFallback(params, nil, "test_tool")
-	if result != "/home/user/project/main.go" {
-		t.Fatalf("expected explicit path, got %q", result)
+func TestTruncateString(t *testing.T) {
+	if truncateString("hello world", 5) != "hello" {
+		t.Fatal("expected truncation")
 	}
-}
-
-func TestResolveFilePathWithFallback_NilManager(t *testing.T) {
-	params := map[string]interface{}{}
-	result := resolveFilePathWithFallback(params, nil, "test_tool")
-	if result != "" {
-		t.Fatalf("expected empty string with nil manager, got %q", result)
+	if truncateString("hi", 10) != "hi" {
+		t.Fatal("expected no truncation")
 	}
-}
-
-func TestResolveFilePathWithFallback_SingleWorkspaceFallback(t *testing.T) {
-	// Create a real workspace manager with a cache containing one workspace
-	cache := workspace.NewCache(5 * time.Minute)
-	cache.Set("/home/user/project/main.go", &workspace.Info{Root: "/home/user/project"})
-
-	mgr := workspace.NewManagerForTest(cache)
-
-	params := map[string]interface{}{}
-	result := resolveFilePathWithFallback(params, mgr, "test_tool")
-
-	if result != "/home/user/project" {
-		t.Fatalf("expected fallback to /home/user/project, got %q", result)
-	}
-
-	// Verify file_path was injected into params
-	if params["file_path"] != "/home/user/project" {
-		t.Fatalf("expected file_path injected into params, got %v", params["file_path"])
-	}
-}
-
-func TestResolveFilePathWithFallback_MultipleWorkspaces_ReturnsEmpty(t *testing.T) {
-	cache := workspace.NewCache(5 * time.Minute)
-	cache.Set("/home/user/project-a/main.go", &workspace.Info{Root: "/home/user/project-a"})
-	cache.Set("/home/user/project-b/main.go", &workspace.Info{Root: "/home/user/project-b"})
-
-	mgr := workspace.NewManagerForTest(cache)
-
-	params := map[string]interface{}{}
-	result := resolveFilePathWithFallback(params, mgr, "test_tool")
-
-	if result != "" {
-		t.Fatalf("expected empty string for multiple workspaces, got %q", result)
-	}
-
-	// Verify file_path was NOT injected
-	if _, ok := params["file_path"]; ok {
-		t.Fatalf("file_path should not be injected when multiple workspaces exist")
-	}
-}
-
-func TestResolveFilePathWithFallback_EmptyCache_ReturnsEmpty(t *testing.T) {
-	cache := workspace.NewCache(5 * time.Minute)
-	mgr := workspace.NewManagerForTest(cache)
-
-	params := map[string]interface{}{}
-	result := resolveFilePathWithFallback(params, mgr, "test_tool")
-
-	if result != "" {
-		t.Fatalf("expected empty string for empty cache, got %q", result)
-	}
-}
-
-func TestResolveFilePathWithFallback_ExplicitPathTakesPriority(t *testing.T) {
-	cache := workspace.NewCache(5 * time.Minute)
-	cache.Set("/home/user/cached-project/main.go", &workspace.Info{Root: "/home/user/cached-project"})
-
-	mgr := workspace.NewManagerForTest(cache)
-
-	params := map[string]interface{}{"file_path": "/home/user/explicit-project/main.go"}
-	result := resolveFilePathWithFallback(params, mgr, "test_tool")
-
-	if result != "/home/user/explicit-project/main.go" {
-		t.Fatalf("expected explicit path to take priority, got %q", result)
-	}
-}
-
-// TestEndToEnd_DetectWorkspace_WithoutFilePath tests the full flow:
-// resolveFilePathWithFallback returns "" → DetectWorkspace → DetectFromParams → CWD fallback
-func TestEndToEnd_DetectWorkspace_WithoutFilePath(t *testing.T) {
-	// Create a temporary workspace with a marker
-	tmpDir := t.TempDir()
-	workspaceDir := filepath.Join(tmpDir, "test-project")
-	if err := os.MkdirAll(workspaceDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "go.mod"), []byte("module test"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create detector with allowed paths
-	detector := workspace.NewDetector()
-	detector.SetAllowedPaths([]string{tmpDir})
-
-	// Test DetectFromParams with empty params (will use CWD fallback)
-	// Note: CWD fallback may not point to our test workspace, but the important thing
-	// is that it doesn't panic or return a hard error about missing file_path
-	params := map[string]interface{}{}
-
-	// resolveFilePathWithFallback should return "" without error
-	result := resolveFilePathWithFallback(params, nil, "test_tool")
-	if result != "" {
-		t.Fatalf("expected empty string, got %q", result)
-	}
-
-	// DetectFromParams should still work (uses CWD fallback)
-	// We can't guarantee CWD is in our test workspace, but it should not panic
-	_, err := detector.DetectFromParams(params)
-	// Error is acceptable here (CWD may not be a valid workspace), but it should
-	// be a workspace detection error, not a "file_path required" error
-	if err != nil {
-		if contains(err.Error(), "file_path parameter is required") {
-			t.Fatalf("should not get 'file_path required' error, got: %v", err)
-		}
-		// Other errors (like CWD not being a valid workspace) are fine
-		t.Logf("DetectFromParams with empty params returned expected error: %v", err)
-	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && searchString(s, substr)
-}
-
-func searchString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/tools/workspace_helpers.go
+++ b/internal/tools/workspace_helpers.go
@@ -22,19 +22,10 @@ func CheckCollectionStatus(ctx context.Context, mem memory.LongTermMemory, colle
 		}
 
 		if !exists {
-			// Collection doesn't exist - tell AI to index first
 			return fmt.Sprintf("❌ Workspace '%s' is not indexed yet.\n\n"+
-				"To enable this operation, please call the 'index_workspace' tool first with:\n"+
-				"{\n"+
-				"  \"file_path\": \"%s\"\n"+
-				"}\n\n"+
-				"Details:\n"+
-				"- Workspace: %s\n"+
-				"- Collection: %s (not created yet)\n",
-				workspacePath,
-				workspacePath,
-				workspacePath,
-				collectionName), nil
+				"Please call 'index_workspace' first with {\"file_path\": \"%s\"}.\n"+
+				"Collection: %s (not created yet)",
+				workspacePath, workspacePath, collectionName), nil
 		}
 	}
 
@@ -45,19 +36,10 @@ func CheckCollectionStatus(ctx context.Context, mem memory.LongTermMemory, colle
 // Returns an error message if no results found, nil otherwise.
 func CheckSearchResults(resultCount int, collectionName, workspacePath string) (string, error) {
 	if resultCount == 0 {
-		// Collection exists but is empty - tell AI to index
 		return fmt.Sprintf("❌ Workspace '%s' appears to be empty or not fully indexed.\n\n"+
-			"To enable this operation, please call the 'index_workspace' tool with:\n"+
-			"{\n"+
-			"  \"file_path\": \"%s\"\n"+
-			"}\n\n"+
-			"Details:\n"+
-			"- Workspace: %s\n"+
-			"- Collection: %s (exists but may be empty)\n",
-			workspacePath,
-			workspacePath,
-			workspacePath,
-			collectionName), nil
+			"Please call 'index_workspace' with {\"file_path\": \"%s\"}.\n"+
+			"Collection: %s (exists but may be empty)",
+			workspacePath, workspacePath, collectionName), nil
 	}
 
 	return "", nil

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -461,12 +461,16 @@ func getAssetName(url string) string {
 	return parts[len(parts)-1]
 }
 
+const maxExtractedZipSize = 200 * 1024 * 1024 // 200 MiB safety limit
+
 func unzip(src, dest string) error {
 	r, err := zip.OpenReader(src)
 	if err != nil {
 		return err
 	}
 	defer r.Close()
+
+	totalExtracted := int64(0)
 
 	for _, f := range r.File {
 		// Normalize ZIP entry name to prevent ZipSlip, including backslash separators
@@ -478,7 +482,7 @@ func unzip(src, dest string) error {
 
 		// Check for ZipSlip (Directory traversal) using filepath.Rel
 		rel, err := filepath.Rel(cleanDest, fpath)
-		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		if err != nil || strings.HasPrefix(rel, "..") {
 			return fmt.Errorf("illegal file path: %s", f.Name)
 		}
 
@@ -513,13 +517,18 @@ func unzip(src, dest string) error {
 			return err
 		}
 
-		_, copyErr := io.Copy(outFile, rc)
+		written, copyErr := io.Copy(outFile, rc)
 
 		closeErr := outFile.Close()
 		rcErr := rc.Close()
 
 		if copyErr != nil {
 			return copyErr
+		}
+
+		totalExtracted += written
+		if totalExtracted > maxExtractedZipSize {
+			return fmt.Errorf("archive exceeds maximum extraction size (%d bytes)", maxExtractedZipSize)
 		}
 		if closeErr != nil {
 			return closeErr

--- a/internal/workspace/detector.go
+++ b/internal/workspace/detector.go
@@ -297,45 +297,6 @@ func (d *Detector) DetectFromPath(filePath string) (*Info, error) {
 	)
 }
 
-// DetectFromParams detects workspace from MCP tool parameters
-func (d *Detector) DetectFromParams(params map[string]interface{}) (*Info, error) {
-	// Priority 1: Check for explicit workspace_root parameter
-	if workspaceRoot, ok := params["workspace_root"]; ok {
-		if rootPath, ok := workspaceRoot.(string); ok && rootPath != "" {
-			return d.DetectFromPath(rootPath)
-		}
-	}
-
-	// Priority 2: Extract file path from standard parameters
-	pathParams := []string{
-		"file_path",
-		"filePath",
-		"path",
-		"file",
-		"source_file",
-		"target_file",
-		"directory",
-		"dir",
-	}
-
-	// Try to find a file path in parameters
-	for _, param := range pathParams {
-		if value, ok := params[param]; ok {
-			if path, ok := value.(string); ok && path != "" {
-				return d.DetectFromPath(path)
-			}
-		}
-	}
-
-	// Fallback: use current working directory of the server
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("no file path in params and failed to get cwd: %w", err)
-	}
-
-	return d.DetectFromPath(cwd)
-}
-
 // findMarkers checks for workspace markers in a directory
 func (d *Detector) findMarkers(dir string) ([]string, string, []string) {
 	var found []string

--- a/internal/workspace/detector_test.go
+++ b/internal/workspace/detector_test.go
@@ -87,67 +87,32 @@ func TestDetector_DetectFromPath_NoMarkers(t *testing.T) {
 	}
 }
 
-func TestDetector_DetectFromParams(t *testing.T) {
-	// Create test workspace
+func TestDetector_DetectFromPath_WalkUp(t *testing.T) {
+	// Create test workspace with .git at root
 	tmpDir := t.TempDir()
 	gitDir := filepath.Join(tmpDir, ".git")
 	if err := os.MkdirAll(gitDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 
-	testFile := filepath.Join(tmpDir, "main.go")
+	// Create a deep file
+	deepDir := filepath.Join(tmpDir, "src", "internal")
+	if err := os.MkdirAll(deepDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	testFile := filepath.Join(deepDir, "main.go")
 	if err := os.WriteFile(testFile, []byte("package main"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
 	detector := NewDetector()
-
-	tests := []struct {
-		name   string
-		params map[string]interface{}
-		want   string
-	}{
-		{
-			name: "workspace_root parameter",
-			params: map[string]interface{}{
-				"workspace_root": tmpDir,
-			},
-			want: tmpDir,
-		},
-		{
-			name: "file_path parameter",
-			params: map[string]interface{}{
-				"file_path": testFile,
-			},
-			want: tmpDir,
-		},
-		{
-			name: "filePath parameter",
-			params: map[string]interface{}{
-				"filePath": testFile,
-			},
-			want: tmpDir,
-		},
-		{
-			name: "path parameter",
-			params: map[string]interface{}{
-				"path": testFile,
-			},
-			want: tmpDir,
-		},
+	info, err := detector.DetectFromPath(testFile)
+	if err != nil {
+		t.Fatalf("DetectFromPath failed: %v", err)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			info, err := detector.DetectFromParams(tt.params)
-			if err != nil {
-				t.Fatalf("DetectFromParams failed: %v", err)
-			}
-
-			if info.Root != tt.want {
-				t.Errorf("Expected root %s, got %s", tt.want, info.Root)
-			}
-		})
+	if info.Root != tmpDir {
+		t.Errorf("Expected root %s, got %s", tmpDir, info.Root)
 	}
 }
 

--- a/internal/workspace/example_test.go
+++ b/internal/workspace/example_test.go
@@ -23,24 +23,6 @@ func ExampleDetector_DetectFromPath() {
 	fmt.Printf("Collection name: %s\n", info.CollectionName())
 }
 
-func ExampleDetector_DetectFromParams() {
-	detector := workspace.NewDetector()
-
-	// Simulate MCP tool parameters
-	params := map[string]interface{}{
-		"file_path": "/home/user/projects/my-app/internal/handlers/user.go",
-		"query":     "user authentication",
-	}
-
-	info, err := detector.DetectFromParams(params)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	fmt.Printf("Detected workspace: %s\n", info.Root)
-	fmt.Printf("Collection: %s\n", info.CollectionName())
-}
-
 func ExampleCache() {
 	// Create cache with 5 minute TTL
 	cache := workspace.NewCache(5 * time.Minute)

--- a/internal/workspace/indexer.go
+++ b/internal/workspace/indexer.go
@@ -1,0 +1,533 @@
+package workspace
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"hash/fnv"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/doITmagic/rag-code-mcp/internal/memory"
+	"github.com/doITmagic/rag-code-mcp/internal/ragcode"
+	"github.com/doITmagic/rag-code-mcp/internal/storage"
+)
+
+// IndexLanguage indexes a specific language in a workspace
+// It runs synchronously. Use StartIndexing for background execution.
+func (m *Manager) IndexLanguage(ctx context.Context, info *Info, language string, collectionName string, force bool) error {
+	// Guard against concurrent indexing for same workspace/language
+	indexKey := info.ID + "-" + language
+	m.indexingMu.Lock()
+	if m.indexing[indexKey] {
+		m.indexingMu.Unlock()
+		return fmt.Errorf("already indexing workspace '%s' language '%s'", info.Root, language)
+	}
+	m.indexing[indexKey] = true
+	m.indexingMu.Unlock()
+
+	defer func() {
+		m.indexingMu.Lock()
+		delete(m.indexing, indexKey)
+		m.indexingMu.Unlock()
+	}()
+
+	log.Printf("🚀 Starting indexing for workspace: %s", info.Root)
+	log.Printf("   Collection: %s", collectionName)
+	log.Printf("   Language: %s", language)
+	log.Printf("   Project type: %s", info.ProjectType)
+
+	// Check if we need to migrate due to dimension mismatch
+	collectionName, _, needsMigration, err := m.CheckAndPrepareMigration(ctx, info, language)
+	if err != nil {
+		return fmt.Errorf("failed to check collection migration: %w", err)
+	}
+
+	// Create collection-specific memory
+	collectionConfig := storage.QdrantConfig{
+		URL:        m.config.Storage.VectorDB.URL,
+		APIKey:     m.config.Storage.VectorDB.APIKey,
+		Collection: collectionName,
+	}
+
+	collectionClient, err := storage.NewQdrantClient(collectionConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create collection client: %w", err)
+	}
+	defer collectionClient.Close()
+
+	ltm := storage.NewQdrantLongTermMemory(collectionClient)
+
+	// Select analyzer based on language (not ProjectType)
+	analyzerManager := ragcode.NewAnalyzerManager()
+	analyzer := analyzerManager.CodeAnalyzerForProjectType(language)
+	if analyzer == nil {
+		return fmt.Errorf("no code analyzer available for language '%s'", language)
+	}
+
+	// Scan workspace once to determine relevant paths per language
+	scan, err := m.scanWorkspace(info)
+	if err != nil {
+		return fmt.Errorf("failed to scan workspace '%s': %w", info.Root, err)
+	}
+
+	languageDirs := scan.LanguageDirs[strings.ToLower(language)]
+	if len(languageDirs) == 0 {
+		return fmt.Errorf("no %s source files detected in workspace '%s'", language, info.Root)
+	}
+
+	// Load previous state
+	stateFile := filepath.Join(info.Root, ".ragcode", "state.json")
+	state, err := LoadState(stateFile)
+	if err != nil {
+		log.Printf("⚠️  Failed to load workspace state: %v", err)
+		state = NewWorkspaceState()
+	}
+
+	// Double check if collection is actually empty in Qdrant. If it is, we MUST re-index regardless of state.
+	// This handles cases where the collection was deleted but state.json remains.
+	pointsCount, err := m.qdrant.GetCollectionPointCount(ctx, collectionName)
+	if err == nil && pointsCount == 0 && !needsMigration {
+		log.Printf("📭 Collection '%s' is empty, forcing full re-index (ignoring state.json)", collectionName)
+		state = NewWorkspaceState()
+	}
+
+	// If migration is needed OR force is true, we MUST perform a full re-index regardless of state
+	if needsMigration || force {
+		log.Printf("🧹 Force indexing: re-indexing all files in collection '%s'", collectionName)
+		state = NewWorkspaceState() // Start with fresh state
+	}
+
+	// Identify changes
+	var filesToIndex []string
+	var filesToDelete []string
+
+	currentFiles := scan.LanguageFiles[strings.ToLower(language)]
+
+	// Add markdown files to the list of files to check if this is the primary language
+	// or if we handle them separately. For simplicity, let's handle docs as part of the language index
+	// but with distinct metadata.
+	// Actually, indexMarkdownFiles handles them separately in collection.
+	// Let's integrate them into the state tracking.
+	currentDocs := scan.DocFiles
+
+	// Check for added or modified files (Code)
+	for _, path := range currentFiles {
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+
+		fileState, exists := state.GetFileState(path)
+		if !exists || info.ModTime().After(fileState.ModTime) || info.Size() != fileState.Size {
+			filesToIndex = append(filesToIndex, path)
+			if exists {
+				filesToDelete = append(filesToDelete, path)
+			}
+		}
+
+		// Update state
+		state.UpdateFile(path, info)
+	}
+
+	// Check for added or modified files (Docs)
+	var docsToIndex []string
+	var docsToDelete []string
+
+	for _, path := range currentDocs {
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+
+		fileState, exists := state.GetFileState(path)
+		if !exists || info.ModTime().After(fileState.ModTime) || info.Size() != fileState.Size {
+			docsToIndex = append(docsToIndex, path)
+			if exists {
+				docsToDelete = append(docsToDelete, path)
+			}
+		}
+
+		// Update state
+		state.UpdateFile(path, info)
+	}
+
+	// Check for deleted files (both code and docs)
+	// We scan the state and check if files still exist in current scan
+	// But scan only has current files.
+	// Better: iterate state.Files and check if they exist on disk.
+	state.mu.RLock()
+	for path := range state.Files {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			// It's deleted. Determine if it was code or doc based on extension
+			ext := strings.ToLower(filepath.Ext(path))
+			if ext == ".md" {
+				docsToDelete = append(docsToDelete, path)
+			} else {
+				filesToDelete = append(filesToDelete, path)
+			}
+		}
+	}
+	state.mu.RUnlock()
+
+	// Process deletions (Code)
+	if len(filesToDelete) > 0 {
+		log.Printf("🗑️  Deleting %d modified/deleted code files from index...", len(filesToDelete))
+		for _, path := range filesToDelete {
+			if err := ltm.DeleteByMetadata(ctx, "file", path); err != nil {
+				log.Printf("⚠️  Failed to delete chunks for %s: %v", path, err)
+			}
+			state.RemoveFile(path)
+		}
+	}
+
+	// Process deletions (Docs)
+	if len(docsToDelete) > 0 {
+		log.Printf("🗑️  Deleting %d modified/deleted doc files from index...", len(docsToDelete))
+		for _, path := range docsToDelete {
+			if err := ltm.DeleteByMetadata(ctx, "file", path); err != nil {
+				log.Printf("⚠️  Failed to delete chunks for %s: %v", path, err)
+			}
+			state.RemoveFile(path)
+		}
+	}
+
+	// Process indexing (Code)
+	if len(filesToIndex) > 0 {
+		log.Printf("📝 Indexing %d new/modified code files...", len(filesToIndex))
+
+		indexer := ragcode.NewIndexer(analyzer, m.llm, ltm)
+
+		startTime := time.Now()
+		numChunks, err := indexer.IndexPaths(ctx, filesToIndex, collectionName)
+		duration := time.Since(startTime)
+
+		if err != nil {
+			return fmt.Errorf("indexing failed: %w", err)
+		}
+		log.Printf("✅ Indexed %d chunks in %v", numChunks, duration)
+	} else {
+		log.Printf("✨ No code changes detected for language '%s'", language)
+	}
+
+	// Process indexing (Docs)
+	if len(docsToIndex) > 0 {
+		log.Printf("📚 Indexing %d new/modified doc files...", len(docsToIndex))
+		// We use indexMarkdownFiles but only for the changed list
+		numDocs := m.indexMarkdownFiles(ctx, docsToIndex, collectionName, ltm)
+		if numDocs > 0 {
+			log.Printf("   Docs chunks indexed: %d", numDocs)
+		}
+	} else {
+		if len(currentDocs) > 0 {
+			log.Printf("✨ No documentation changes detected")
+		}
+	}
+
+	// Save state
+	if err := state.Save(stateFile); err != nil {
+		log.Printf("⚠️  Failed to save workspace state: %v", err)
+	}
+
+	m.recordFingerprint(info, language, scan)
+	return nil
+}
+
+// checkAndReindexIfNeeded checks if any files have changed and triggers incremental re-indexing if needed
+// This is called automatically when a tool accesses an existing workspace collection
+func (m *Manager) checkAndReindexIfNeeded(ctx context.Context, info *Info, language string, collectionName string) {
+	// 1. Check if we need to migrate/re-index due to dimension mismatch or empty collection
+	_, _, needsMigration, err := m.CheckAndPrepareMigration(ctx, info, language)
+	if err == nil && needsMigration {
+		log.Printf("ℹ️ Migration or re-index needed for '%s', triggering IndexLanguage", collectionName)
+		if err := m.IndexLanguage(ctx, info, language, collectionName, false); err != nil {
+			log.Printf("⚠️  Migration/Re-index failed: %v", err)
+		}
+		return
+	}
+
+	// 2. Load workspace state
+	stateFile := filepath.Join(info.Root, ".ragcode", "state.json")
+	state, err := LoadState(stateFile)
+	if err != nil {
+		// If state doesn't exist, we can't check for changes
+		// This is normal for first-time indexing
+		return
+	}
+
+	// Quick scan to check if any files have changed
+	scan, err := m.scanWorkspace(info)
+	if err != nil {
+		log.Printf("⚠️  Auto-reindex check failed for workspace '%s': %v", info.Root, err)
+		return
+	}
+
+	currentFiles := scan.LanguageFiles[strings.ToLower(language)]
+	if len(currentFiles) == 0 {
+		return
+	}
+
+	// Check if any files have been modified, added, or deleted
+	hasChanges := false
+
+	// Check for modifications or additions
+	for _, path := range currentFiles {
+		fileInfo, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+
+		fileState, exists := state.GetFileState(path)
+		if !exists || fileInfo.ModTime().After(fileState.ModTime) || fileInfo.Size() != fileState.Size {
+			hasChanges = true
+			break
+		}
+	}
+
+	// Check for deletions (files in state but not in current scan)
+	if !hasChanges {
+		currentFileMap := make(map[string]bool)
+		for _, p := range currentFiles {
+			currentFileMap[p] = true
+		}
+
+		state.mu.RLock()
+		for path := range state.Files {
+			if _, err := os.Stat(path); os.IsNotExist(err) {
+				hasChanges = true
+				break
+			}
+		}
+		state.mu.RUnlock()
+	}
+
+	// If changes detected, trigger incremental re-indexing
+	if hasChanges {
+		log.Printf("🔄 Auto-detected file changes in workspace '%s' (language: %s), triggering incremental re-indexing...", info.Root, language)
+		if err := m.IndexLanguage(ctx, info, language, collectionName, false); err != nil {
+			log.Printf("⚠️  Auto-reindex failed: %v", err)
+		}
+	}
+}
+
+// indexMarkdownFiles indexes provided markdown files (already discovered during scan)
+func (m *Manager) indexMarkdownFiles(ctx context.Context, markdownFiles []string, collectionName string, ltm memory.LongTermMemory) int {
+	if len(markdownFiles) == 0 {
+		return 0
+	}
+
+	log.Printf("📚 Found %d markdown file(s), indexing documentation...", len(markdownFiles))
+
+	totalChunks := 0
+	for _, path := range markdownFiles {
+		chunks, err := m.indexMarkdownFile(ctx, path, collectionName, ltm)
+		if err != nil {
+			log.Printf("⚠️  Failed to index markdown file %s: %v", path, err)
+			continue
+		}
+		totalChunks += chunks
+	}
+
+	return totalChunks
+}
+
+// indexMarkdownFile chunks and indexes a single markdown file
+func (m *Manager) indexMarkdownFile(ctx context.Context, path string, collectionName string, ltm memory.LongTermMemory) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var (
+		chunks          []string
+		current         strings.Builder
+		maxChars        = 2000 // Increased for better context
+		emptyLineCount  = 0
+		lastLineHeading = false
+	)
+
+	flushChunk := func() {
+		text := strings.TrimSpace(current.String())
+		if text != "" {
+			chunks = append(chunks, text)
+		}
+		current.Reset()
+		emptyLineCount = 0
+		lastLineHeading = false
+	}
+
+	isHeading := func(line string) bool {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "#") {
+			return false
+		}
+		// Count leading hashes
+		i := 0
+		for i < len(trimmed) && trimmed[i] == '#' {
+			i++
+		}
+		// Valid markdown heading: 1-6 hashes followed by a space or end of string
+		return i >= 1 && i <= 6 && (i == len(trimmed) || trimmed[i] == ' ')
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmedLine := strings.TrimSpace(line)
+
+		// Empty line handling
+		if trimmedLine == "" {
+			emptyLineCount++
+			// Only flush if we have multiple empty lines AND we're not after a heading
+			if emptyLineCount >= 2 && !lastLineHeading && current.Len() > 0 {
+				flushChunk()
+				continue
+			}
+			// Keep single empty line for formatting
+			if current.Len() > 0 {
+				current.WriteString("\n")
+			}
+			continue
+		}
+
+		// Reset empty line counter on content
+		emptyLineCount = 0
+
+		// New section: flush on heading unless it's the first content
+		if isHeading(line) && current.Len() > 500 { // Keep headings together if chunk is small for better context
+			flushChunk()
+		}
+
+		// Size check
+		if current.Len()+len(line)+1 > maxChars {
+			flushChunk()
+		}
+
+		if current.Len() > 0 {
+			current.WriteString("\n")
+		}
+		current.WriteString(line)
+		lastLineHeading = isHeading(line)
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("scan %s: %w", path, err)
+	}
+	flushChunk()
+
+	// Index each chunk
+	for i, text := range chunks {
+		emb, err := m.llm.Embed(ctx, text)
+		if err != nil {
+			return i, fmt.Errorf("embed failed for %s chunk %d: %w", path, i, err)
+		}
+
+		h := fnv.New64a()
+		h.Write([]byte(fmt.Sprintf("%s#%d", path, i)))
+		id := fmt.Sprintf("%d", h.Sum64())
+
+		doc := memory.Document{
+			ID:        id,
+			Content:   text,
+			Embedding: emb,
+			Metadata: map[string]interface{}{
+				"file":       path,
+				"chunk_id":   i,
+				"source":     collectionName,
+				"chunk_type": "markdown",
+			},
+		}
+
+		if err := ltm.Store(ctx, doc); err != nil {
+			return i, fmt.Errorf("store failed for %s: %w", id, err)
+		}
+	}
+
+	return len(chunks), nil
+}
+
+// IsIndexing checks if a workspace is currently being indexed
+func (m *Manager) IsIndexing(workspaceID string) bool {
+	m.indexingMu.RLock()
+	defer m.indexingMu.RUnlock()
+	return m.indexing[workspaceID]
+}
+
+// StartIndexing explicitly starts background indexing for a workspace language
+func (m *Manager) StartIndexing(ctx context.Context, info *Info, language string, force bool) error {
+	collectionName := info.CollectionNameForLanguage(language)
+
+	// Check if already indexing BEFORE starting goroutine for immediate feedback
+	indexKey := info.ID + "-" + language
+	m.indexingMu.RLock()
+	if m.indexing[indexKey] {
+		m.indexingMu.RUnlock()
+		return fmt.Errorf("workspace '%s' language '%s' is already being indexed", info.Root, language)
+	}
+	m.indexingMu.RUnlock()
+
+	// Start background indexing
+	go func() {
+		// IndexLanguage now handles its own concurrency guarding and lock management
+		if err := m.IndexLanguage(context.Background(), info, language, collectionName, force); err != nil {
+			log.Printf("❌ Background indexing failed: %v", err)
+		}
+	}()
+
+	return nil
+}
+
+// EnsureWorkspaceIndexed triggers indexing for all detected languages in the workspace
+func (m *Manager) EnsureWorkspaceIndexed(ctx context.Context, rootPath string) error {
+	info, err := m.detector.DetectFromPath(rootPath)
+	if err != nil {
+		return err
+	}
+	// ID is generated by detector
+	if m.config != nil && m.config.Workspace.CollectionPrefix != "" {
+		info.CollectionPrefix = m.config.Workspace.CollectionPrefix
+	}
+
+	var errs []string
+
+	// Check which languages have analyzers available
+	analyzerManager := ragcode.NewAnalyzerManager()
+
+	// Helper to check if we have an analyzer for a language
+	hasAnalyzer := func(lang string) bool {
+		return analyzerManager.CodeAnalyzerForProjectType(lang) != nil
+	}
+
+	// Helper to index language
+	indexLang := func(lang string) {
+		if !hasAnalyzer(lang) {
+			log.Printf("⚠️  Skipping language '%s' - no analyzer available", lang)
+			return
+		}
+		colName := info.CollectionNameForLanguage(lang)
+		if err := m.IndexLanguage(ctx, info, lang, colName, false); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", lang, err))
+		}
+	}
+
+	if len(info.Languages) == 0 {
+		lang := info.ProjectType
+		if lang != "" && lang != "unknown" {
+			indexLang(lang)
+		}
+	} else {
+		for _, lang := range info.Languages {
+			indexLang(lang)
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("indexing errors: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -1,15 +1,11 @@
 package workspace
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"hash/fnv"
-	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -17,7 +13,6 @@ import (
 	"github.com/doITmagic/rag-code-mcp/internal/config"
 	"github.com/doITmagic/rag-code-mcp/internal/llm"
 	"github.com/doITmagic/rag-code-mcp/internal/memory"
-	"github.com/doITmagic/rag-code-mcp/internal/ragcode"
 	"github.com/doITmagic/rag-code-mcp/internal/storage"
 )
 
@@ -25,6 +20,7 @@ import (
 type Manager struct {
 	detector *Detector
 	cache    *Cache
+	registry *Registry
 	qdrant   *storage.QdrantClient
 	llm      llm.Provider
 	config   *config.Config
@@ -50,162 +46,6 @@ type Manager struct {
 	collLocks   map[string]*sync.Mutex
 }
 
-type workspaceScan struct {
-	LanguageDirs  map[string][]string
-	LanguageFiles map[string][]string // Track individual files per language
-	DocFiles      []string
-	TotalFiles    int
-	GeneratedAt   time.Time
-}
-
-var defaultSkipDirs = map[string]struct{}{
-	".git":         {},
-	".idea":        {},
-	".vscode":      {},
-	"node_modules": {},
-	"vendor":       {},
-	"dist":         {},
-	"build":        {},
-	"storage":      {},
-	"public":       {},
-}
-
-func addDirForLanguage(scan *workspaceScan, cache map[string]map[string]struct{}, language, dir string) {
-	if dir == "" {
-		return
-	}
-	lang := strings.ToLower(language)
-	if _, ok := cache[lang]; !ok {
-		cache[lang] = make(map[string]struct{})
-	}
-	if _, exists := cache[lang][dir]; exists {
-		return
-	}
-	cache[lang][dir] = struct{}{}
-	if scan.LanguageDirs == nil {
-		scan.LanguageDirs = make(map[string][]string)
-	}
-	scan.LanguageDirs[lang] = append(scan.LanguageDirs[lang], dir)
-}
-
-func addFileForLanguage(scan *workspaceScan, language, path string) {
-	lang := strings.ToLower(language)
-	if scan.LanguageFiles == nil {
-		scan.LanguageFiles = make(map[string][]string)
-	}
-	scan.LanguageFiles[lang] = append(scan.LanguageFiles[lang], path)
-}
-
-func (m *Manager) scanWorkspace(info *Info) (*workspaceScan, error) {
-	// Validate root path before scanning to prevent broad filesystem access
-	if isInvalidRoot(info.Root) {
-		return nil, fmt.Errorf("cannot scan invalid workspace root: %s", info.Root)
-	}
-
-	scan := &workspaceScan{
-		LanguageDirs:  make(map[string][]string),
-		LanguageFiles: make(map[string][]string),
-		DocFiles:      make([]string, 0),
-		GeneratedAt:   time.Now(),
-	}
-	dirCache := make(map[string]map[string]struct{})
-	err := filepath.WalkDir(info.Root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
-		if d.IsDir() {
-			if path == info.Root {
-				return nil
-			}
-			if _, skip := defaultSkipDirs[d.Name()]; skip {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-
-		scan.TotalFiles++
-		ext := strings.ToLower(filepath.Ext(path))
-		switch ext {
-		case ".go":
-			addDirForLanguage(scan, dirCache, "go", filepath.Dir(path))
-			addFileForLanguage(scan, "go", path)
-		case ".php":
-			addDirForLanguage(scan, dirCache, "php", filepath.Dir(path))
-			addFileForLanguage(scan, "php", path)
-		case ".py":
-			addDirForLanguage(scan, dirCache, "python", filepath.Dir(path))
-			addFileForLanguage(scan, "python", path)
-		case ".html", ".htm":
-			addDirForLanguage(scan, dirCache, "html", filepath.Dir(path))
-			addFileForLanguage(scan, "html", path)
-		case ".md":
-			scan.DocFiles = append(scan.DocFiles, path)
-		default:
-			// ignored
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return scan, nil
-}
-
-func (s *workspaceScan) fingerprint(language string) string {
-	h := fnv.New64a()
-	lang := strings.ToLower(language)
-	fmt.Fprintf(h, "%s|%d|%d", lang, s.TotalFiles, len(s.DocFiles))
-	dirs := append([]string(nil), s.LanguageDirs[lang]...)
-	sort.Strings(dirs)
-	for _, dir := range dirs {
-		h.Write([]byte(dir))
-		h.Write([]byte("|"))
-	}
-	docs := append([]string(nil), s.DocFiles...)
-	sort.Strings(docs)
-	for _, doc := range docs {
-		h.Write([]byte(doc))
-		h.Write([]byte("|"))
-	}
-	return fmt.Sprintf("%x", h.Sum64())
-}
-
-func (m *Manager) fingerprintKey(info *Info, language string) string {
-	return info.ID + "-" + strings.ToLower(language)
-}
-
-func (m *Manager) recordFingerprint(info *Info, language string, scan *workspaceScan) {
-	if scan == nil {
-		return
-	}
-	fp := scan.fingerprint(language)
-	key := m.fingerprintKey(info, language)
-	m.scanMu.Lock()
-	if m.scanFingerprints == nil {
-		m.scanFingerprints = make(map[string]string)
-	}
-	m.scanFingerprints[key] = fp
-	m.scanMu.Unlock()
-}
-
-// NeedsReindex rescans the workspace and determines if tracked files changed for the language.
-// Returns true when changes are detected or no previous fingerprint exists.
-func (m *Manager) NeedsReindex(info *Info, language string) (bool, error) {
-	scan, err := m.scanWorkspace(info)
-	if err != nil {
-		return false, err
-	}
-	fp := scan.fingerprint(language)
-	key := m.fingerprintKey(info, language)
-	m.scanMu.RLock()
-	prev := m.scanFingerprints[key]
-	m.scanMu.RUnlock()
-	if prev == "" {
-		return true, nil
-	}
-	return prev != fp, nil
-}
-
 // NewManager creates a new workspace manager
 func NewManager(qdrant *storage.QdrantClient, llm llm.Provider, cfg *config.Config) *Manager {
 	// Create detector with config or defaults
@@ -226,6 +66,7 @@ func NewManager(qdrant *storage.QdrantClient, llm llm.Provider, cfg *config.Conf
 	return &Manager{
 		detector:         detector,
 		cache:            NewCache(5 * time.Minute),
+		registry:         NewRegistry(""),
 		qdrant:           qdrant,
 		llm:              llm,
 		config:           cfg,
@@ -235,6 +76,54 @@ func NewManager(qdrant *storage.QdrantClient, llm llm.Provider, cfg *config.Conf
 		watchers:         make(map[string]*FileWatcher),
 		collLocks:        make(map[string]*sync.Mutex),
 	}
+}
+
+// GetRegistry returns the workspace registry.
+func (m *Manager) GetRegistry() *Registry {
+	return m.registry
+}
+
+// ResolveWorkspace resolves a workspace from the registry.
+// If "workspace" param is given, looks it up by name.
+// If exactly one workspace is registered, returns it automatically.
+// If multiple are registered and none specified, returns a formatted list as error.
+// If none are registered, returns an error telling the AI to index first.
+func (m *Manager) ResolveWorkspace(params map[string]interface{}) (*Info, error) {
+	// Check if AI specified a workspace name
+	if wsName, ok := params["workspace"].(string); ok && wsName != "" {
+		entry := m.registry.FindByName(wsName)
+		if entry == nil {
+			return nil, fmt.Errorf("workspace %q not found in registry.\n\n%s", wsName, m.registry.FormatList())
+		}
+		return m.registryEntryToInfo(entry), nil
+	}
+
+	// Auto-resolve: single workspace → use it
+	if single := m.registry.Single(); single != nil {
+		return m.registryEntryToInfo(single), nil
+	}
+
+	// No workspaces or multiple without selection
+	n := m.registry.Len()
+	if n == 0 {
+		return nil, fmt.Errorf("no workspaces indexed.\n\nPlease call 'index_workspace' first with:\n  {\"file_path\": \"/path/to/your/project\"}")
+	}
+
+	return nil, fmt.Errorf("%s", m.registry.FormatList())
+}
+
+// registryEntryToInfo converts a RegistryEntry to an Info struct.
+func (m *Manager) registryEntryToInfo(entry *RegistryEntry) *Info {
+	info := &Info{
+		Root:       entry.Root,
+		ID:         entry.ID,
+		Languages:  entry.Languages,
+		DetectedAt: entry.IndexedAt,
+	}
+	if m.config != nil && m.config.Workspace.CollectionPrefix != "" {
+		info.CollectionPrefix = m.config.Workspace.CollectionPrefix
+	}
+	return info
 }
 
 // getCollectionMutex returns a mutex for a specific collection name, creating it if needed
@@ -255,81 +144,65 @@ func (m *Manager) getCollectionMutex(name string) *sync.Mutex {
 	return lock
 }
 
-// DetectWorkspace detects workspace from tool parameters
+// DetectWorkspace detects workspace from tool parameters.
+// Used exclusively by index_workspace to find the real project root via walk-up.
+//
+// Resolution order (3 strategies):
+//  1. If params contain a path (workspace_root/file_path/filePath/path) → DetectFromPath (walk-up)
+//  2. If no path provided → fallback to registry (1 ws → auto, multiple → list)
+//  3. If registry is empty → clear error asking AI to provide the path once
 func (m *Manager) DetectWorkspace(params map[string]interface{}) (*Info, error) {
-	// PRIORITY 1: Check for explicit workspace_root parameter
-	if workspaceRoot, ok := params["workspace_root"]; ok {
-		if rootPath, ok := workspaceRoot.(string); ok && rootPath != "" {
-			log.Printf("🎯 Using explicit workspace_root: %s", rootPath)
-
-			// Expand tilde if present
-			if strings.HasPrefix(rootPath, "~/") {
-				if home, err := os.UserHomeDir(); err == nil {
-					rootPath = filepath.Join(home, rootPath[2:])
-				}
-			}
-
-			// Convert to absolute path
-			absPath, err := filepath.Abs(rootPath)
-			if err != nil {
-				return nil, fmt.Errorf("invalid workspace_root path: %w", err)
-			}
-
-			// Use the detector to validate and get workspace info
-			// This will still run all security checks
-			info, err := m.detector.DetectFromPath(absPath)
-			if err != nil {
-				return nil, fmt.Errorf("workspace_root validation failed: %w", err)
-			}
-
-			// Set collection prefix from config
-			if m.config != nil && m.config.Workspace.CollectionPrefix != "" {
-				info.CollectionPrefix = m.config.Workspace.CollectionPrefix
-			}
-
-			// Cache by the explicit root
-			m.cache.Set(absPath, info)
-
-			return info, nil
+	// Strategy 1: Extract path from params: workspace_root > file_path > filePath > path
+	var rawPath string
+	for _, key := range []string{"workspace_root", "file_path", "filePath", "path"} {
+		if v, ok := params[key].(string); ok && v != "" {
+			rawPath = v
+			break
 		}
 	}
 
-	// PRIORITY 2: Fall back to automatic detection from file_path
-	// Try to extract file path for cache key
-	var cacheKey string
-	for _, param := range []string{"file_path", "filePath", "path", "file"} {
-		if value, ok := params[param]; ok {
-			if path, ok := value.(string); ok && path != "" {
-				cacheKey = path
-				break
+	// If we have a path, detect via walk-up (original behavior)
+	if rawPath != "" {
+		// Expand tilde
+		if strings.HasPrefix(rawPath, "~/") {
+			if home, err := os.UserHomeDir(); err == nil {
+				rawPath = filepath.Join(home, rawPath[2:])
 			}
 		}
-	}
 
-	// Check cache if we have a key
-	if cacheKey != "" {
-		if cached := m.cache.Get(cacheKey); cached != nil {
-			return cached, nil
+		absPath, err := filepath.Abs(rawPath)
+		if err != nil {
+			return nil, fmt.Errorf("invalid path: %w", err)
 		}
+
+		info, err := m.detector.DetectFromPath(absPath)
+		if err != nil {
+			return nil, err
+		}
+
+		if m.config != nil && m.config.Workspace.CollectionPrefix != "" {
+			info.CollectionPrefix = m.config.Workspace.CollectionPrefix
+		}
+
+		m.cache.Set(absPath, info)
+		return info, nil
 	}
 
-	// Detect workspace
-	info, err := m.detector.DetectFromParams(params)
-	if err != nil {
-		return nil, err
+	// Strategy 2: No path provided — fallback to registry
+	if single := m.registry.Single(); single != nil {
+		log.Printf("[workspace] No path provided, using single registered workspace: %s", single.Root)
+		return m.registryEntryToInfo(single), nil
 	}
 
-	// Set collection prefix from config
-	if m.config != nil && m.config.Workspace.CollectionPrefix != "" {
-		info.CollectionPrefix = m.config.Workspace.CollectionPrefix
+	n := m.registry.Len()
+	if n > 1 {
+		return nil, fmt.Errorf("no file path provided and multiple workspaces registered.\n\n%s\n\nPlease re-call index_workspace with {\"workspace\": \"<name>\"} to select one.", m.registry.FormatList())
 	}
 
-	// Cache result
-	if cacheKey != "" {
-		m.cache.Set(cacheKey, info)
-	}
-
-	return info, nil
+	// Strategy 3: Registry is empty — ask AI to provide path once
+	return nil, fmt.Errorf("no workspaces registered yet.\n\n" +
+		"Please call index_workspace with {\"file_path\": \"/path/to/your/project\"} or {\"workspace_root\": \"/path/to/your/project\"}.\n" +
+		"This only needs to be done once — the workspace will be remembered permanently.")
 }
 
 // GetMemoryForWorkspace returns a memory instance for the workspace
@@ -492,606 +365,6 @@ func (m *Manager) GetMemoriesForAllLanguages(ctx context.Context, info *Info) (m
 	}
 
 	return memories, nil
-}
-
-// IndexLanguage indexes a specific language in a workspace
-// It runs synchronously. Use StartIndexing for background execution.
-func (m *Manager) IndexLanguage(ctx context.Context, info *Info, language string, collectionName string, force bool) error {
-	// Guard against concurrent indexing for same workspace/language
-	indexKey := info.ID + "-" + language
-	m.indexingMu.Lock()
-	if m.indexing[indexKey] {
-		m.indexingMu.Unlock()
-		return fmt.Errorf("already indexing workspace '%s' language '%s'", info.Root, language)
-	}
-	m.indexing[indexKey] = true
-	m.indexingMu.Unlock()
-
-	defer func() {
-		m.indexingMu.Lock()
-		delete(m.indexing, indexKey)
-		m.indexingMu.Unlock()
-	}()
-
-	log.Printf("🚀 Starting indexing for workspace: %s", info.Root)
-	log.Printf("   Collection: %s", collectionName)
-	log.Printf("   Language: %s", language)
-	log.Printf("   Project type: %s", info.ProjectType)
-
-	// Check if we need to migrate due to dimension mismatch
-	collectionName, _, needsMigration, err := m.CheckAndPrepareMigration(ctx, info, language)
-	if err != nil {
-		return fmt.Errorf("failed to check collection migration: %w", err)
-	}
-
-	// Create collection-specific memory
-	collectionConfig := storage.QdrantConfig{
-		URL:        m.config.Storage.VectorDB.URL,
-		APIKey:     m.config.Storage.VectorDB.APIKey,
-		Collection: collectionName,
-	}
-
-	collectionClient, err := storage.NewQdrantClient(collectionConfig)
-	if err != nil {
-		return fmt.Errorf("failed to create collection client: %w", err)
-	}
-	defer collectionClient.Close()
-
-	ltm := storage.NewQdrantLongTermMemory(collectionClient)
-
-	// Select analyzer based on language (not ProjectType)
-	analyzerManager := ragcode.NewAnalyzerManager()
-	analyzer := analyzerManager.CodeAnalyzerForProjectType(language)
-	if analyzer == nil {
-		return fmt.Errorf("no code analyzer available for language '%s'", language)
-	}
-
-	// Scan workspace once to determine relevant paths per language
-	scan, err := m.scanWorkspace(info)
-	if err != nil {
-		return fmt.Errorf("failed to scan workspace '%s': %w", info.Root, err)
-	}
-
-	languageDirs := scan.LanguageDirs[strings.ToLower(language)]
-	if len(languageDirs) == 0 {
-		return fmt.Errorf("no %s source files detected in workspace '%s'", language, info.Root)
-	}
-
-	// Load previous state
-	stateFile := filepath.Join(info.Root, ".ragcode", "state.json")
-	state, err := LoadState(stateFile)
-	if err != nil {
-		log.Printf("⚠️  Failed to load workspace state: %v", err)
-		state = NewWorkspaceState()
-	}
-
-	// Double check if collection is actually empty in Qdrant. If it is, we MUST re-index regardless of state.
-	// This handles cases where the collection was deleted but state.json remains.
-	pointsCount, err := m.qdrant.GetCollectionPointCount(ctx, collectionName)
-	if err == nil && pointsCount == 0 && !needsMigration {
-		log.Printf("📭 Collection '%s' is empty, forcing full re-index (ignoring state.json)", collectionName)
-		state = NewWorkspaceState()
-	}
-
-	// If migration is needed OR force is true, we MUST perform a full re-index regardless of state
-	if needsMigration || force {
-		log.Printf("🧹 Force indexing: re-indexing all files in collection '%s'", collectionName)
-		state = NewWorkspaceState() // Start with fresh state
-	}
-
-	// Identify changes
-	var filesToIndex []string
-	var filesToDelete []string
-
-	currentFiles := scan.LanguageFiles[strings.ToLower(language)]
-
-	// Add markdown files to the list of files to check if this is the primary language
-	// or if we handle them separately. For simplicity, let's handle docs as part of the language index
-	// but with distinct metadata.
-	// Actually, indexMarkdownFiles handles them separately in collection.
-	// Let's integrate them into the state tracking.
-	currentDocs := scan.DocFiles
-
-	// Check for added or modified files (Code)
-	for _, path := range currentFiles {
-		info, err := os.Stat(path)
-		if err != nil {
-			continue
-		}
-
-		fileState, exists := state.GetFileState(path)
-		if !exists || info.ModTime().After(fileState.ModTime) || info.Size() != fileState.Size {
-			filesToIndex = append(filesToIndex, path)
-			if exists {
-				filesToDelete = append(filesToDelete, path)
-			}
-		}
-
-		// Update state
-		state.UpdateFile(path, info)
-	}
-
-	// Check for added or modified files (Docs)
-	var docsToIndex []string
-	var docsToDelete []string
-
-	for _, path := range currentDocs {
-		info, err := os.Stat(path)
-		if err != nil {
-			continue
-		}
-
-		fileState, exists := state.GetFileState(path)
-		if !exists || info.ModTime().After(fileState.ModTime) || info.Size() != fileState.Size {
-			docsToIndex = append(docsToIndex, path)
-			if exists {
-				docsToDelete = append(docsToDelete, path)
-			}
-		}
-
-		// Update state
-		state.UpdateFile(path, info)
-	}
-
-	// Check for deleted files (both code and docs)
-	// We scan the state and check if files still exist in current scan
-	// But scan only has current files.
-	// Better: iterate state.Files and check if they exist on disk.
-	state.mu.RLock()
-	for path := range state.Files {
-		if _, err := os.Stat(path); os.IsNotExist(err) {
-			// It's deleted. Determine if it was code or doc based on extension
-			ext := strings.ToLower(filepath.Ext(path))
-			if ext == ".md" {
-				docsToDelete = append(docsToDelete, path)
-			} else {
-				filesToDelete = append(filesToDelete, path)
-			}
-		}
-	}
-	state.mu.RUnlock()
-
-	// Process deletions (Code)
-	if len(filesToDelete) > 0 {
-		log.Printf("🗑️  Deleting %d modified/deleted code files from index...", len(filesToDelete))
-		for _, path := range filesToDelete {
-			if err := ltm.DeleteByMetadata(ctx, "file", path); err != nil {
-				log.Printf("⚠️  Failed to delete chunks for %s: %v", path, err)
-			}
-			state.RemoveFile(path)
-		}
-	}
-
-	// Process deletions (Docs)
-	if len(docsToDelete) > 0 {
-		log.Printf("🗑️  Deleting %d modified/deleted doc files from index...", len(docsToDelete))
-		for _, path := range docsToDelete {
-			if err := ltm.DeleteByMetadata(ctx, "file", path); err != nil {
-				log.Printf("⚠️  Failed to delete chunks for %s: %v", path, err)
-			}
-			state.RemoveFile(path)
-		}
-	}
-
-	// Process indexing (Code)
-	if len(filesToIndex) > 0 {
-		log.Printf("📝 Indexing %d new/modified code files...", len(filesToIndex))
-
-		indexer := ragcode.NewIndexer(analyzer, m.llm, ltm)
-
-		startTime := time.Now()
-		numChunks, err := indexer.IndexPaths(ctx, filesToIndex, collectionName)
-		duration := time.Since(startTime)
-
-		if err != nil {
-			return fmt.Errorf("indexing failed: %w", err)
-		}
-		log.Printf("✅ Indexed %d chunks in %v", numChunks, duration)
-	} else {
-		log.Printf("✨ No code changes detected for language '%s'", language)
-	}
-
-	// Process indexing (Docs)
-	if len(docsToIndex) > 0 {
-		log.Printf("📚 Indexing %d new/modified doc files...", len(docsToIndex))
-		// We use indexMarkdownFiles but only for the changed list
-		numDocs := m.indexMarkdownFiles(ctx, docsToIndex, collectionName, ltm)
-		if numDocs > 0 {
-			log.Printf("   Docs chunks indexed: %d", numDocs)
-		}
-	} else {
-		if len(currentDocs) > 0 {
-			log.Printf("✨ No documentation changes detected")
-		}
-	}
-
-	// Save state
-	if err := state.Save(stateFile); err != nil {
-		log.Printf("⚠️  Failed to save workspace state: %v", err)
-	}
-
-	m.recordFingerprint(info, language, scan)
-	return nil
-}
-
-// checkAndReindexIfNeeded checks if any files have changed and triggers incremental re-indexing if needed
-// This is called automatically when a tool accesses an existing workspace collection
-func (m *Manager) checkAndReindexIfNeeded(ctx context.Context, info *Info, language string, collectionName string) {
-	// 1. Check if we need to migrate/re-index due to dimension mismatch or empty collection
-	_, _, needsMigration, err := m.CheckAndPrepareMigration(ctx, info, language)
-	if err == nil && needsMigration {
-		log.Printf("ℹ️ Migration or re-index needed for '%s', triggering IndexLanguage", collectionName)
-		if err := m.IndexLanguage(ctx, info, language, collectionName, false); err != nil {
-			log.Printf("⚠️  Migration/Re-index failed: %v", err)
-		}
-		return
-	}
-
-	// 2. Load workspace state
-	stateFile := filepath.Join(info.Root, ".ragcode", "state.json")
-	state, err := LoadState(stateFile)
-	if err != nil {
-		// If state doesn't exist, we can't check for changes
-		// This is normal for first-time indexing
-		return
-	}
-
-	// Quick scan to check if any files have changed
-	scan, err := m.scanWorkspace(info)
-	if err != nil {
-		log.Printf("⚠️  Auto-reindex check failed for workspace '%s': %v", info.Root, err)
-		return
-	}
-
-	currentFiles := scan.LanguageFiles[strings.ToLower(language)]
-	if len(currentFiles) == 0 {
-		return
-	}
-
-	// Check if any files have been modified, added, or deleted
-	hasChanges := false
-
-	// Check for modifications or additions
-	for _, path := range currentFiles {
-		fileInfo, err := os.Stat(path)
-		if err != nil {
-			continue
-		}
-
-		fileState, exists := state.GetFileState(path)
-		if !exists || fileInfo.ModTime().After(fileState.ModTime) || fileInfo.Size() != fileState.Size {
-			hasChanges = true
-			break
-		}
-	}
-
-	// Check for deletions (files in state but not in current scan)
-	if !hasChanges {
-		currentFileMap := make(map[string]bool)
-		for _, p := range currentFiles {
-			currentFileMap[p] = true
-		}
-
-		state.mu.RLock()
-		for path := range state.Files {
-			if _, err := os.Stat(path); os.IsNotExist(err) {
-				hasChanges = true
-				break
-			}
-		}
-		state.mu.RUnlock()
-	}
-
-	// If changes detected, trigger incremental re-indexing
-	if hasChanges {
-		log.Printf("🔄 Auto-detected file changes in workspace '%s' (language: %s), triggering incremental re-indexing...", info.Root, language)
-		if err := m.IndexLanguage(ctx, info, language, collectionName, false); err != nil {
-			log.Printf("⚠️  Auto-reindex failed: %v", err)
-		}
-	}
-}
-
-// indexMarkdownFiles indexes provided markdown files (already discovered during scan)
-func (m *Manager) indexMarkdownFiles(ctx context.Context, markdownFiles []string, collectionName string, ltm memory.LongTermMemory) int {
-	if len(markdownFiles) == 0 {
-		return 0
-	}
-
-	log.Printf("📚 Found %d markdown file(s), indexing documentation...", len(markdownFiles))
-
-	totalChunks := 0
-	for _, path := range markdownFiles {
-		chunks, err := m.indexMarkdownFile(ctx, path, collectionName, ltm)
-		if err != nil {
-			log.Printf("⚠️  Failed to index markdown file %s: %v", path, err)
-			continue
-		}
-		totalChunks += chunks
-	}
-
-	return totalChunks
-}
-
-// indexMarkdownFile chunks and indexes a single markdown file
-func (m *Manager) indexMarkdownFile(ctx context.Context, path string, collectionName string, ltm memory.LongTermMemory) (int, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return 0, fmt.Errorf("open %s: %w", path, err)
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-
-	var (
-		chunks          []string
-		current         strings.Builder
-		maxChars        = 2000 // Increased for better context
-		emptyLineCount  = 0
-		lastLineHeading = false
-	)
-
-	flushChunk := func() {
-		text := strings.TrimSpace(current.String())
-		if text != "" {
-			chunks = append(chunks, text)
-		}
-		current.Reset()
-		emptyLineCount = 0
-		lastLineHeading = false
-	}
-
-	isHeading := func(line string) bool {
-		trimmed := strings.TrimSpace(line)
-		if !strings.HasPrefix(trimmed, "#") {
-			return false
-		}
-		// Count leading hashes
-		i := 0
-		for i < len(trimmed) && trimmed[i] == '#' {
-			i++
-		}
-		// Valid markdown heading: 1-6 hashes followed by a space or end of string
-		return i >= 1 && i <= 6 && (i == len(trimmed) || trimmed[i] == ' ')
-	}
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		trimmedLine := strings.TrimSpace(line)
-
-		// Empty line handling
-		if trimmedLine == "" {
-			emptyLineCount++
-			// Only flush if we have multiple empty lines AND we're not after a heading
-			if emptyLineCount >= 2 && !lastLineHeading && current.Len() > 0 {
-				flushChunk()
-				continue
-			}
-			// Keep single empty line for formatting
-			if current.Len() > 0 {
-				current.WriteString("\n")
-			}
-			continue
-		}
-
-		// Reset empty line counter on content
-		emptyLineCount = 0
-
-		// New section: flush on heading unless it's the first content
-		if isHeading(line) && current.Len() > 500 { // Keep headings together if chunk is small for better context
-			flushChunk()
-		}
-
-		// Size check
-		if current.Len()+len(line)+1 > maxChars {
-			flushChunk()
-		}
-
-		if current.Len() > 0 {
-			current.WriteString("\n")
-		}
-		current.WriteString(line)
-		lastLineHeading = isHeading(line)
-	}
-	if err := scanner.Err(); err != nil {
-		return 0, fmt.Errorf("scan %s: %w", path, err)
-	}
-	flushChunk()
-
-	// Index each chunk
-	for i, text := range chunks {
-		emb, err := m.llm.Embed(ctx, text)
-		if err != nil {
-			return i, fmt.Errorf("embed failed for %s chunk %d: %w", path, i, err)
-		}
-
-		h := fnv.New64a()
-		h.Write([]byte(fmt.Sprintf("%s#%d", path, i)))
-		id := fmt.Sprintf("%d", h.Sum64())
-
-		doc := memory.Document{
-			ID:        id,
-			Content:   text,
-			Embedding: emb,
-			Metadata: map[string]interface{}{
-				"file":       path,
-				"chunk_id":   i,
-				"source":     collectionName,
-				"chunk_type": "markdown",
-			},
-		}
-
-		if err := ltm.Store(ctx, doc); err != nil {
-			return i, fmt.Errorf("store failed for %s: %w", id, err)
-		}
-	}
-
-	return len(chunks), nil
-}
-
-// IsIndexing checks if a workspace is currently being indexed
-func (m *Manager) IsIndexing(workspaceID string) bool {
-	m.indexingMu.RLock()
-	defer m.indexingMu.RUnlock()
-	return m.indexing[workspaceID]
-}
-
-// CheckAndPrepareMigration checks if collection needs migration due to dimension mismatch
-// Returns: (newCollectionName, oldCollectionName, needsMigration, error)
-func (m *Manager) CheckAndPrepareMigration(ctx context.Context, info *Info, language string) (string, string, bool, error) {
-	collectionName := info.CollectionNameForLanguage(language)
-
-	// Use per-collection lock to prevent concurrent reset/migration of the same collection
-	lock := m.getCollectionMutex(collectionName)
-	lock.Lock()
-	defer lock.Unlock()
-
-	// Check if collection exists
-	exists, err := m.qdrant.CollectionExists(ctx, collectionName)
-	if err != nil {
-		return collectionName, "", false, fmt.Errorf("failed to check collection: %w", err)
-	}
-
-	if !exists {
-		// Collection doesn't exist, no migration needed
-		return collectionName, "", false, nil
-	}
-
-	// Try to get collection info to check vector dimensions
-	collectionInfo, err := m.qdrant.GetCollectionInfo(ctx, collectionName)
-	if err != nil {
-		log.Printf("⚠️ Could not get collection info, proceeding without migration: %v", err)
-		return collectionName, "", false, nil
-	}
-
-	// Get current embedding dimension from LLM config
-	currentDimension := m.llm.GetEmbeddingDimension()
-	existingDimension := collectionInfo.VectorSize
-
-	// Case 1: Dimension mismatch - hard reset
-	if existingDimension > 0 && currentDimension > 0 && existingDimension != currentDimension {
-		log.Printf("🔄 Dimension mismatch detected in collection '%s': %d vs %d", collectionName, existingDimension, currentDimension)
-		log.Printf("🧹 Resetting collection '%s' to use %d dimensions", collectionName, currentDimension)
-
-		if err := m.qdrant.DeleteCollection(ctx, collectionName); err != nil {
-			log.Printf("⚠️ Failed to delete old collection during reset: %v", err)
-		}
-
-		if err := m.qdrant.CreateCollection(ctx, collectionName, int(currentDimension)); err != nil {
-			return collectionName, "", false, fmt.Errorf("failed to recreate collection with new dimension: %w", err)
-		}
-
-		return collectionName, "", true, nil
-	}
-
-	// Case 2: Collection exists but is empty - trigger full re-index to be safe
-	if collectionInfo.PointsCount == 0 {
-		log.Printf("ℹ️ Collection '%s' exists but is empty. Triggering full re-index.", collectionName)
-		return collectionName, "", true, nil
-	}
-
-	return collectionName, "", false, nil
-}
-
-// DeleteLanguageCollection deletes the Qdrant collection and associated state for a language
-func (m *Manager) DeleteLanguageCollection(ctx context.Context, info *Info, language string) error {
-	collectionName := info.CollectionNameForLanguage(language)
-
-	// Use per-collection lock to prevent racing with migration/init operations
-	lock := m.getCollectionMutex(collectionName)
-	lock.Lock()
-	defer lock.Unlock()
-
-	// Remove from cache
-	m.memoryMu.Lock()
-	if mem, ok := m.memories[collectionName]; ok {
-		if closer, ok := mem.(interface{ Close() error }); ok {
-			closer.Close()
-		}
-		delete(m.memories, collectionName)
-	}
-	m.memoryMu.Unlock()
-
-	// Delete from Qdrant
-	if err := m.qdrant.DeleteCollection(ctx, collectionName); err != nil {
-		log.Printf("⚠️ Failed to delete collection %s from Qdrant: %v", collectionName, err)
-	}
-
-	return nil
-}
-
-// StartIndexing explicitly starts background indexing for a workspace language
-func (m *Manager) StartIndexing(ctx context.Context, info *Info, language string, force bool) error {
-	collectionName := info.CollectionNameForLanguage(language)
-
-	// Check if already indexing BEFORE starting goroutine for immediate feedback
-	indexKey := info.ID + "-" + language
-	m.indexingMu.RLock()
-	if m.indexing[indexKey] {
-		m.indexingMu.RUnlock()
-		return fmt.Errorf("workspace '%s' language '%s' is already being indexed", info.Root, language)
-	}
-	m.indexingMu.RUnlock()
-
-	// Start background indexing
-	go func() {
-		// IndexLanguage now handles its own concurrency guarding and lock management
-		if err := m.IndexLanguage(context.Background(), info, language, collectionName, force); err != nil {
-			log.Printf("❌ Background indexing failed: %v", err)
-		}
-	}()
-
-	return nil
-}
-
-// EnsureWorkspaceIndexed triggers indexing for all detected languages in the workspace
-func (m *Manager) EnsureWorkspaceIndexed(ctx context.Context, rootPath string) error {
-	info, err := m.detector.DetectFromPath(rootPath)
-	if err != nil {
-		return err
-	}
-	// ID is generated by detector
-	if m.config != nil && m.config.Workspace.CollectionPrefix != "" {
-		info.CollectionPrefix = m.config.Workspace.CollectionPrefix
-	}
-
-	var errs []string
-
-	// Check which languages have analyzers available
-	analyzerManager := ragcode.NewAnalyzerManager()
-
-	// Helper to check if we have an analyzer for a language
-	hasAnalyzer := func(lang string) bool {
-		return analyzerManager.CodeAnalyzerForProjectType(lang) != nil
-	}
-
-	// Helper to index language
-	indexLang := func(lang string) {
-		if !hasAnalyzer(lang) {
-			log.Printf("⚠️  Skipping language '%s' - no analyzer available", lang)
-			return
-		}
-		colName := info.CollectionNameForLanguage(lang)
-		if err := m.IndexLanguage(ctx, info, lang, colName, false); err != nil {
-			errs = append(errs, fmt.Sprintf("%s: %v", lang, err))
-		}
-	}
-
-	if len(info.Languages) == 0 {
-		lang := info.ProjectType
-		if lang != "" && lang != "unknown" {
-			indexLang(lang)
-		}
-	} else {
-		for _, lang := range info.Languages {
-			indexLang(lang)
-		}
-	}
-
-	if len(errs) > 0 {
-		return fmt.Errorf("indexing errors: %s", strings.Join(errs, "; "))
-	}
-	return nil
 }
 
 // StartWatcher starts the file watcher for a workspace if not already running

--- a/internal/workspace/migration.go
+++ b/internal/workspace/migration.go
@@ -1,0 +1,195 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CheckAndPrepareMigration checks if collection needs migration due to dimension mismatch
+// Returns: (newCollectionName, oldCollectionName, needsMigration, error)
+func (m *Manager) CheckAndPrepareMigration(ctx context.Context, info *Info, language string) (string, string, bool, error) {
+	collectionName := info.CollectionNameForLanguage(language)
+
+	// Use per-collection lock to prevent concurrent reset/migration of the same collection
+	lock := m.getCollectionMutex(collectionName)
+	lock.Lock()
+	defer lock.Unlock()
+
+	// Check if collection exists
+	exists, err := m.qdrant.CollectionExists(ctx, collectionName)
+	if err != nil {
+		return collectionName, "", false, fmt.Errorf("failed to check collection: %w", err)
+	}
+
+	if !exists {
+		// Collection doesn't exist, no migration needed
+		return collectionName, "", false, nil
+	}
+
+	// Try to get collection info to check vector dimensions
+	collectionInfo, err := m.qdrant.GetCollectionInfo(ctx, collectionName)
+	if err != nil {
+		log.Printf("⚠️ Could not get collection info, proceeding without migration: %v", err)
+		return collectionName, "", false, nil
+	}
+
+	// Get current embedding dimension from LLM config
+	currentDimension := m.llm.GetEmbeddingDimension()
+	existingDimension := collectionInfo.VectorSize
+
+	// Case 1: Dimension mismatch - hard reset
+	if existingDimension > 0 && currentDimension > 0 && existingDimension != currentDimension {
+		log.Printf("🔄 Dimension mismatch detected in collection '%s': %d vs %d", collectionName, existingDimension, currentDimension)
+		log.Printf("🧹 Resetting collection '%s' to use %d dimensions", collectionName, currentDimension)
+
+		if err := m.qdrant.DeleteCollection(ctx, collectionName); err != nil {
+			log.Printf("⚠️ Failed to delete old collection during reset: %v", err)
+		}
+
+		if err := m.qdrant.CreateCollection(ctx, collectionName, int(currentDimension)); err != nil {
+			return collectionName, "", false, fmt.Errorf("failed to recreate collection with new dimension: %w", err)
+		}
+
+		return collectionName, "", true, nil
+	}
+
+	// Case 2: Collection exists but is empty - trigger full re-index to be safe
+	if collectionInfo.PointsCount == 0 {
+		log.Printf("ℹ️ Collection '%s' exists but is empty. Triggering full re-index.", collectionName)
+		return collectionName, "", true, nil
+	}
+
+	return collectionName, "", false, nil
+}
+
+// DeleteLanguageCollection deletes the Qdrant collection and associated state for a language
+func (m *Manager) DeleteLanguageCollection(ctx context.Context, info *Info, language string) error {
+	collectionName := info.CollectionNameForLanguage(language)
+
+	// Use per-collection lock to prevent racing with migration/init operations
+	lock := m.getCollectionMutex(collectionName)
+	lock.Lock()
+	defer lock.Unlock()
+
+	// Remove from cache
+	m.memoryMu.Lock()
+	if mem, ok := m.memories[collectionName]; ok {
+		if closer, ok := mem.(interface{ Close() error }); ok {
+			closer.Close()
+		}
+		delete(m.memories, collectionName)
+	}
+	m.memoryMu.Unlock()
+
+	// Delete from Qdrant
+	if err := m.qdrant.DeleteCollection(ctx, collectionName); err != nil {
+		log.Printf("⚠️ Failed to delete collection %s from Qdrant: %v", collectionName, err)
+	}
+
+	return nil
+}
+
+// MigrateExistingWorkspaces scans AllowedWorkspacePaths (and common project dirs)
+// for directories containing .ragcode/state.json — a marker that they were previously indexed.
+// Each found workspace is detected via DetectFromPath and registered in the persistent registry.
+// This ensures users upgrading from older versions have their registry pre-populated at startup.
+func (m *Manager) MigrateExistingWorkspaces() {
+	if m.detector == nil || m.registry == nil {
+		return
+	}
+
+	// If registry already has workspaces, skip migration
+	if m.registry.Len() > 0 {
+		log.Printf("[migrate] Registry already has %d workspace(s), skipping migration", m.registry.Len())
+		return
+	}
+
+	// Collect candidate directories to scan
+	var candidates []string
+	if m.config != nil {
+		candidates = append(candidates, m.config.Workspace.AllowedWorkspacePaths...)
+	}
+
+	if len(candidates) == 0 {
+		log.Printf("[migrate] No AllowedWorkspacePaths configured, skipping migration")
+		return
+	}
+
+	log.Printf("[migrate] Scanning %d allowed path(s) for previously indexed workspaces...", len(candidates))
+
+	found := 0
+	for _, base := range candidates {
+		// Expand tilde
+		if strings.HasPrefix(base, "~/") {
+			if home, err := os.UserHomeDir(); err == nil {
+				base = filepath.Join(home, base[2:])
+			}
+		}
+
+		absBase, err := filepath.Abs(base)
+		if err != nil {
+			continue
+		}
+
+		// Check if the base itself has .ragcode/state.json
+		if m.tryMigrateDir(absBase) {
+			found++
+		}
+
+		// Scan one level deep (immediate subdirectories = typical project layout)
+		entries, err := os.ReadDir(absBase)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			subDir := filepath.Join(absBase, entry.Name())
+			if m.tryMigrateDir(subDir) {
+				found++
+			}
+		}
+	}
+
+	if found > 0 {
+		log.Printf("[migrate] ✓ Migrated %d workspace(s) into registry", found)
+	} else {
+		log.Printf("[migrate] No previously indexed workspaces found")
+	}
+}
+
+// tryMigrateDir checks if dir contains .ragcode/state.json, detects workspace, and registers it.
+func (m *Manager) tryMigrateDir(dir string) bool {
+	stateFile := filepath.Join(dir, ".ragcode", "state.json")
+	if _, err := os.Stat(stateFile); err != nil {
+		return false
+	}
+
+	// Already registered?
+	if entry := m.registry.FindByRoot(dir); entry != nil {
+		return false
+	}
+
+	info, err := m.detector.DetectFromPath(dir)
+	if err != nil {
+		log.Printf("[migrate] Skipping %s: %v", dir, err)
+		return false
+	}
+
+	if m.config != nil && m.config.Workspace.CollectionPrefix != "" {
+		info.CollectionPrefix = m.config.Workspace.CollectionPrefix
+	}
+
+	if err := m.registry.Register(info); err != nil {
+		log.Printf("[migrate] Failed to register %s: %v", dir, err)
+		return false
+	}
+
+	log.Printf("[migrate] Registered workspace: %s (%s)", info.Root, info.ID)
+	return true
+}

--- a/internal/workspace/multi_search.go
+++ b/internal/workspace/multi_search.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/doITmagic/rag-code-mcp/internal/memory"
 )
@@ -32,6 +33,34 @@ func (m *Manager) GetAllIndexedCollectionNames() []string {
 	}
 
 	return names
+}
+
+// GetSingleWorkspaceRoot returns the workspace root if exactly one workspace is cached.
+// Returns empty string if zero or multiple workspaces are active.
+// This is used as a fallback when file_path is not provided by the AI caller.
+func (m *Manager) GetSingleWorkspaceRoot() string {
+	m.cache.mu.RLock()
+	defer m.cache.mu.RUnlock()
+
+	// Collect unique workspace roots from cache entries
+	roots := make(map[string]struct{})
+	now := time.Now()
+	for _, entry := range m.cache.entries {
+		if now.After(entry.expiresAt) {
+			continue
+		}
+		if entry.info != nil && entry.info.Root != "" {
+			roots[entry.info.Root] = struct{}{}
+		}
+	}
+
+	if len(roots) == 1 {
+		for root := range roots {
+			return root
+		}
+	}
+
+	return ""
 }
 
 // SearchAllWorkspaces searches across all indexed workspace collections

--- a/internal/workspace/multi_search.go
+++ b/internal/workspace/multi_search.go
@@ -3,7 +3,6 @@ package workspace
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/doITmagic/rag-code-mcp/internal/memory"
 )
@@ -33,34 +32,6 @@ func (m *Manager) GetAllIndexedCollectionNames() []string {
 	}
 
 	return names
-}
-
-// GetSingleWorkspaceRoot returns the workspace root if exactly one workspace is cached.
-// Returns empty string if zero or multiple workspaces are active.
-// This is used as a fallback when file_path is not provided by the AI caller.
-func (m *Manager) GetSingleWorkspaceRoot() string {
-	m.cache.mu.RLock()
-	defer m.cache.mu.RUnlock()
-
-	// Collect unique workspace roots from cache entries
-	roots := make(map[string]struct{})
-	now := time.Now()
-	for _, entry := range m.cache.entries {
-		if now.After(entry.expiresAt) {
-			continue
-		}
-		if entry.info != nil && entry.info.Root != "" {
-			roots[entry.info.Root] = struct{}{}
-		}
-	}
-
-	if len(roots) == 1 {
-		for root := range roots {
-			return root
-		}
-	}
-
-	return ""
 }
 
 // SearchAllWorkspaces searches across all indexed workspace collections

--- a/internal/workspace/multi_search_test.go
+++ b/internal/workspace/multi_search_test.go
@@ -1,90 +1,142 @@
 package workspace
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
 
-func TestGetSingleWorkspaceRoot_EmptyCache(t *testing.T) {
-	cache := NewCache(5 * time.Minute)
-	m := &Manager{cache: cache}
+func TestRegistry_RegisterAndFind(t *testing.T) {
+	tmp := t.TempDir()
+	regPath := filepath.Join(tmp, "workspaces.json")
+	reg := NewRegistry(regPath)
 
-	root := m.GetSingleWorkspaceRoot()
-	if root != "" {
-		t.Fatalf("expected empty string for empty cache, got %q", root)
+	info := &Info{
+		Root:      "/home/user/project-a",
+		ID:        "ws-a",
+		Languages: []string{"go"},
+	}
+	if err := reg.Register(info); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	if reg.Len() != 1 {
+		t.Fatalf("expected 1 workspace, got %d", reg.Len())
+	}
+
+	entry := reg.FindByName("project-a")
+	if entry == nil {
+		t.Fatal("FindByName returned nil")
+	}
+	if entry.Root != "/home/user/project-a" {
+		t.Fatalf("expected root /home/user/project-a, got %q", entry.Root)
+	}
+
+	entry = reg.FindByRoot("/home/user/project-a")
+	if entry == nil {
+		t.Fatal("FindByRoot returned nil")
 	}
 }
 
-func TestGetSingleWorkspaceRoot_SingleWorkspace(t *testing.T) {
-	cache := NewCache(5 * time.Minute)
-	cache.Set("/home/user/project-a/main.go", &Info{Root: "/home/user/project-a"})
+func TestRegistry_Single(t *testing.T) {
+	tmp := t.TempDir()
+	reg := NewRegistry(filepath.Join(tmp, "workspaces.json"))
 
-	m := &Manager{cache: cache}
+	if reg.Single() != nil {
+		t.Fatal("expected nil for empty registry")
+	}
 
-	root := m.GetSingleWorkspaceRoot()
-	if root != "/home/user/project-a" {
-		t.Fatalf("expected /home/user/project-a, got %q", root)
+	reg.Register(&Info{Root: "/home/user/project-a", ID: "ws-a"})
+	if s := reg.Single(); s == nil {
+		t.Fatal("expected single workspace")
+	}
+
+	reg.Register(&Info{Root: "/home/user/project-b", ID: "ws-b"})
+	if reg.Single() != nil {
+		t.Fatal("expected nil for multiple workspaces")
 	}
 }
 
-func TestGetSingleWorkspaceRoot_SingleWorkspaceMultipleCacheKeys(t *testing.T) {
-	cache := NewCache(5 * time.Minute)
-	// Same workspace root cached under different file paths
-	cache.Set("/home/user/project-a/main.go", &Info{Root: "/home/user/project-a"})
-	cache.Set("/home/user/project-a/internal/pkg/foo.go", &Info{Root: "/home/user/project-a"})
+func TestRegistry_Remove(t *testing.T) {
+	tmp := t.TempDir()
+	reg := NewRegistry(filepath.Join(tmp, "workspaces.json"))
 
-	m := &Manager{cache: cache}
+	reg.Register(&Info{Root: "/home/user/project-a", ID: "ws-a"})
+	reg.Register(&Info{Root: "/home/user/project-b", ID: "ws-b"})
 
-	root := m.GetSingleWorkspaceRoot()
-	if root != "/home/user/project-a" {
-		t.Fatalf("expected /home/user/project-a (deduplicated), got %q", root)
+	if err := reg.Remove("project-a"); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+	if reg.Len() != 1 {
+		t.Fatalf("expected 1 workspace after remove, got %d", reg.Len())
 	}
 }
 
-func TestGetSingleWorkspaceRoot_MultipleWorkspaces(t *testing.T) {
-	cache := NewCache(5 * time.Minute)
-	cache.Set("/home/user/project-a/main.go", &Info{Root: "/home/user/project-a"})
-	cache.Set("/home/user/project-b/main.go", &Info{Root: "/home/user/project-b"})
+func TestRegistry_Persistence(t *testing.T) {
+	tmp := t.TempDir()
+	regPath := filepath.Join(tmp, "workspaces.json")
 
-	m := &Manager{cache: cache}
+	reg1 := NewRegistry(regPath)
+	reg1.Register(&Info{Root: "/home/user/project-a", ID: "ws-a", Languages: []string{"go"}})
 
-	root := m.GetSingleWorkspaceRoot()
-	if root != "" {
-		t.Fatalf("expected empty string for multiple workspaces, got %q", root)
+	// Load from disk
+	reg2 := NewRegistry(regPath)
+	if reg2.Len() != 1 {
+		t.Fatalf("expected 1 workspace after reload, got %d", reg2.Len())
+	}
+	entry := reg2.FindByName("project-a")
+	if entry == nil || entry.Root != "/home/user/project-a" {
+		t.Fatal("persisted workspace not found after reload")
 	}
 }
 
-func TestGetSingleWorkspaceRoot_ExpiredEntries(t *testing.T) {
-	cache := NewCache(1 * time.Millisecond)
-	cache.Set("/home/user/project-a/main.go", &Info{Root: "/home/user/project-a"})
+func TestRegistry_UpdateExisting(t *testing.T) {
+	tmp := t.TempDir()
+	reg := NewRegistry(filepath.Join(tmp, "workspaces.json"))
 
-	// Wait for cache to expire
-	time.Sleep(5 * time.Millisecond)
+	reg.Register(&Info{Root: "/home/user/project-a", ID: "ws-a", Languages: []string{"go"}})
+	reg.Register(&Info{Root: "/home/user/project-a", ID: "ws-a", Languages: []string{"go", "python"}})
 
-	m := &Manager{cache: cache}
-
-	root := m.GetSingleWorkspaceRoot()
-	if root != "" {
-		t.Fatalf("expected empty string for expired cache, got %q", root)
+	if reg.Len() != 1 {
+		t.Fatalf("expected 1 workspace (updated), got %d", reg.Len())
+	}
+	entry := reg.FindByRoot("/home/user/project-a")
+	if len(entry.Languages) != 2 {
+		t.Fatalf("expected 2 languages after update, got %d", len(entry.Languages))
 	}
 }
 
-func TestGetSingleWorkspaceRoot_MixedExpiredAndValid(t *testing.T) {
-	cache := NewCache(1 * time.Millisecond)
-	cache.Set("/home/user/project-old/main.go", &Info{Root: "/home/user/project-old"})
+func TestRegistry_FormatList(t *testing.T) {
+	tmp := t.TempDir()
+	reg := NewRegistry(filepath.Join(tmp, "workspaces.json"))
 
-	// Wait for first entry to expire
-	time.Sleep(5 * time.Millisecond)
+	msg := reg.FormatList()
+	if msg == "" {
+		t.Fatal("expected non-empty message for empty registry")
+	}
 
-	// Add a fresh entry with a new cache (longer TTL)
-	// We need to directly manipulate the cache since NewCache sets TTL globally
-	cache.ttl = 5 * time.Minute
-	cache.Set("/home/user/project-new/main.go", &Info{Root: "/home/user/project-new"})
+	reg.Register(&Info{Root: "/home/user/project-a", ID: "ws-a"})
+	reg.Register(&Info{Root: "/home/user/project-b", ID: "ws-b"})
 
-	m := &Manager{cache: cache}
-
-	root := m.GetSingleWorkspaceRoot()
-	if root != "/home/user/project-new" {
-		t.Fatalf("expected /home/user/project-new (only valid entry), got %q", root)
+	msg = reg.FormatList()
+	if msg == "" {
+		t.Fatal("expected non-empty formatted list")
 	}
 }
+
+func TestRegistry_FileCreation(t *testing.T) {
+	tmp := t.TempDir()
+	subDir := filepath.Join(tmp, "nested", "dir")
+	regPath := filepath.Join(subDir, "workspaces.json")
+
+	reg := NewRegistry(regPath)
+	reg.Register(&Info{Root: "/home/user/project-a", ID: "ws-a"})
+
+	if _, err := os.Stat(regPath); os.IsNotExist(err) {
+		t.Fatal("registry file was not created")
+	}
+}
+
+// Keep time import used for IndexedAt checks
+var _ = time.Now

--- a/internal/workspace/multi_search_test.go
+++ b/internal/workspace/multi_search_test.go
@@ -1,0 +1,90 @@
+package workspace
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGetSingleWorkspaceRoot_EmptyCache(t *testing.T) {
+	cache := NewCache(5 * time.Minute)
+	m := &Manager{cache: cache}
+
+	root := m.GetSingleWorkspaceRoot()
+	if root != "" {
+		t.Fatalf("expected empty string for empty cache, got %q", root)
+	}
+}
+
+func TestGetSingleWorkspaceRoot_SingleWorkspace(t *testing.T) {
+	cache := NewCache(5 * time.Minute)
+	cache.Set("/home/user/project-a/main.go", &Info{Root: "/home/user/project-a"})
+
+	m := &Manager{cache: cache}
+
+	root := m.GetSingleWorkspaceRoot()
+	if root != "/home/user/project-a" {
+		t.Fatalf("expected /home/user/project-a, got %q", root)
+	}
+}
+
+func TestGetSingleWorkspaceRoot_SingleWorkspaceMultipleCacheKeys(t *testing.T) {
+	cache := NewCache(5 * time.Minute)
+	// Same workspace root cached under different file paths
+	cache.Set("/home/user/project-a/main.go", &Info{Root: "/home/user/project-a"})
+	cache.Set("/home/user/project-a/internal/pkg/foo.go", &Info{Root: "/home/user/project-a"})
+
+	m := &Manager{cache: cache}
+
+	root := m.GetSingleWorkspaceRoot()
+	if root != "/home/user/project-a" {
+		t.Fatalf("expected /home/user/project-a (deduplicated), got %q", root)
+	}
+}
+
+func TestGetSingleWorkspaceRoot_MultipleWorkspaces(t *testing.T) {
+	cache := NewCache(5 * time.Minute)
+	cache.Set("/home/user/project-a/main.go", &Info{Root: "/home/user/project-a"})
+	cache.Set("/home/user/project-b/main.go", &Info{Root: "/home/user/project-b"})
+
+	m := &Manager{cache: cache}
+
+	root := m.GetSingleWorkspaceRoot()
+	if root != "" {
+		t.Fatalf("expected empty string for multiple workspaces, got %q", root)
+	}
+}
+
+func TestGetSingleWorkspaceRoot_ExpiredEntries(t *testing.T) {
+	cache := NewCache(1 * time.Millisecond)
+	cache.Set("/home/user/project-a/main.go", &Info{Root: "/home/user/project-a"})
+
+	// Wait for cache to expire
+	time.Sleep(5 * time.Millisecond)
+
+	m := &Manager{cache: cache}
+
+	root := m.GetSingleWorkspaceRoot()
+	if root != "" {
+		t.Fatalf("expected empty string for expired cache, got %q", root)
+	}
+}
+
+func TestGetSingleWorkspaceRoot_MixedExpiredAndValid(t *testing.T) {
+	cache := NewCache(1 * time.Millisecond)
+	cache.Set("/home/user/project-old/main.go", &Info{Root: "/home/user/project-old"})
+
+	// Wait for first entry to expire
+	time.Sleep(5 * time.Millisecond)
+
+	// Add a fresh entry with a new cache (longer TTL)
+	// We need to directly manipulate the cache since NewCache sets TTL globally
+	cache.ttl = 5 * time.Minute
+	cache.Set("/home/user/project-new/main.go", &Info{Root: "/home/user/project-new"})
+
+	m := &Manager{cache: cache}
+
+	root := m.GetSingleWorkspaceRoot()
+	if root != "/home/user/project-new" {
+		t.Fatalf("expected /home/user/project-new (only valid entry), got %q", root)
+	}
+}

--- a/internal/workspace/registry.go
+++ b/internal/workspace/registry.go
@@ -1,0 +1,191 @@
+package workspace
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RegistryEntry represents a single indexed workspace in the registry.
+type RegistryEntry struct {
+	Name       string   `json:"name"`
+	Root       string   `json:"root"`
+	ID         string   `json:"id"`
+	Languages  []string `json:"languages,omitempty"`
+	IndexedAt  time.Time `json:"indexed_at"`
+}
+
+// Registry is a persistent store of all indexed workspaces.
+// Stored as JSON at ~/.local/share/ragcode/workspaces.json.
+type Registry struct {
+	mu         sync.RWMutex
+	Workspaces []RegistryEntry `json:"workspaces"`
+	filePath   string
+}
+
+// DefaultRegistryPath returns the default path for the registry file.
+func DefaultRegistryPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "workspaces.json"
+	}
+	return filepath.Join(home, ".local", "share", "ragcode", "workspaces.json")
+}
+
+// NewRegistry creates a new registry and loads existing data from disk.
+func NewRegistry(path string) *Registry {
+	if path == "" {
+		path = DefaultRegistryPath()
+	}
+	r := &Registry{filePath: path}
+	if err := r.load(); err != nil {
+		log.Printf("[registry] no existing registry at %s: %v", path, err)
+	}
+	return r
+}
+
+// load reads the registry from disk.
+func (r *Registry) load() error {
+	data, err := os.ReadFile(r.filePath)
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return json.Unmarshal(data, &r.Workspaces)
+}
+
+// save writes the registry to disk.
+func (r *Registry) save() error {
+	if err := os.MkdirAll(filepath.Dir(r.filePath), 0755); err != nil {
+		return fmt.Errorf("create registry dir: %w", err)
+	}
+	data, err := json.MarshalIndent(r.Workspaces, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal registry: %w", err)
+	}
+	return os.WriteFile(r.filePath, data, 0644)
+}
+
+// Register adds or updates a workspace in the registry and persists to disk.
+func (r *Registry) Register(info *Info) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	name := filepath.Base(info.Root)
+
+	// Update existing entry if same root
+	for i, entry := range r.Workspaces {
+		if entry.Root == info.Root {
+			r.Workspaces[i].Languages = info.Languages
+			r.Workspaces[i].IndexedAt = time.Now()
+			r.Workspaces[i].ID = info.ID
+			r.Workspaces[i].Name = name
+			return r.save()
+		}
+	}
+
+	// Add new entry
+	r.Workspaces = append(r.Workspaces, RegistryEntry{
+		Name:      name,
+		Root:      info.Root,
+		ID:        info.ID,
+		Languages: info.Languages,
+		IndexedAt: time.Now(),
+	})
+	return r.save()
+}
+
+// Remove deletes a workspace from the registry by name or root.
+func (r *Registry) Remove(nameOrRoot string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for i, entry := range r.Workspaces {
+		if entry.Name == nameOrRoot || entry.Root == nameOrRoot {
+			r.Workspaces = append(r.Workspaces[:i], r.Workspaces[i+1:]...)
+			return r.save()
+		}
+	}
+	return fmt.Errorf("workspace %q not found in registry", nameOrRoot)
+}
+
+// FindByName returns the entry matching the given name (case-insensitive).
+func (r *Registry) FindByName(name string) *RegistryEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	lower := strings.ToLower(name)
+	for i, entry := range r.Workspaces {
+		if strings.ToLower(entry.Name) == lower {
+			return &r.Workspaces[i]
+		}
+	}
+	return nil
+}
+
+// FindByRoot returns the entry matching the given root path.
+func (r *Registry) FindByRoot(root string) *RegistryEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for i, entry := range r.Workspaces {
+		if entry.Root == root {
+			return &r.Workspaces[i]
+		}
+	}
+	return nil
+}
+
+// List returns all registered workspaces sorted by name.
+func (r *Registry) List() []RegistryEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	out := make([]RegistryEntry, len(r.Workspaces))
+	copy(out, r.Workspaces)
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+// Len returns the number of registered workspaces.
+func (r *Registry) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.Workspaces)
+}
+
+// Single returns the only workspace if exactly one is registered, nil otherwise.
+func (r *Registry) Single() *RegistryEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if len(r.Workspaces) == 1 {
+		return &r.Workspaces[0]
+	}
+	return nil
+}
+
+// FormatList returns a human-readable list of workspaces for the AI to choose from.
+func (r *Registry) FormatList() string {
+	entries := r.List()
+	if len(entries) == 0 {
+		return "No workspaces indexed. Please call 'index_workspace' first."
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Multiple workspaces indexed (%d). Please specify 'workspace' parameter with one of:\n\n", len(entries)))
+	for i, e := range entries {
+		sb.WriteString(fmt.Sprintf("  %d. **%s** → %s (indexed %s)\n",
+			i+1, e.Name, e.Root, e.IndexedAt.Format("2006-01-02 15:04")))
+	}
+	return sb.String()
+}

--- a/internal/workspace/scanner.go
+++ b/internal/workspace/scanner.go
@@ -1,0 +1,167 @@
+package workspace
+
+import (
+	"fmt"
+	"hash/fnv"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+type workspaceScan struct {
+	LanguageDirs  map[string][]string
+	LanguageFiles map[string][]string // Track individual files per language
+	DocFiles      []string
+	TotalFiles    int
+	GeneratedAt   time.Time
+}
+
+var defaultSkipDirs = map[string]struct{}{
+	".git":         {},
+	".idea":        {},
+	".vscode":      {},
+	"node_modules": {},
+	"vendor":       {},
+	"dist":         {},
+	"build":        {},
+	"storage":      {},
+	"public":       {},
+}
+
+func addDirForLanguage(scan *workspaceScan, cache map[string]map[string]struct{}, language, dir string) {
+	if dir == "" {
+		return
+	}
+	lang := strings.ToLower(language)
+	if _, ok := cache[lang]; !ok {
+		cache[lang] = make(map[string]struct{})
+	}
+	if _, exists := cache[lang][dir]; exists {
+		return
+	}
+	cache[lang][dir] = struct{}{}
+	if scan.LanguageDirs == nil {
+		scan.LanguageDirs = make(map[string][]string)
+	}
+	scan.LanguageDirs[lang] = append(scan.LanguageDirs[lang], dir)
+}
+
+func addFileForLanguage(scan *workspaceScan, language, path string) {
+	lang := strings.ToLower(language)
+	if scan.LanguageFiles == nil {
+		scan.LanguageFiles = make(map[string][]string)
+	}
+	scan.LanguageFiles[lang] = append(scan.LanguageFiles[lang], path)
+}
+
+func (m *Manager) scanWorkspace(info *Info) (*workspaceScan, error) {
+	// Validate root path before scanning to prevent broad filesystem access
+	if isInvalidRoot(info.Root) {
+		return nil, fmt.Errorf("cannot scan invalid workspace root: %s", info.Root)
+	}
+
+	scan := &workspaceScan{
+		LanguageDirs:  make(map[string][]string),
+		LanguageFiles: make(map[string][]string),
+		DocFiles:      make([]string, 0),
+		GeneratedAt:   time.Now(),
+	}
+	dirCache := make(map[string]map[string]struct{})
+	err := filepath.WalkDir(info.Root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if path == info.Root {
+				return nil
+			}
+			if _, skip := defaultSkipDirs[d.Name()]; skip {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		scan.TotalFiles++
+		ext := strings.ToLower(filepath.Ext(path))
+		switch ext {
+		case ".go":
+			addDirForLanguage(scan, dirCache, "go", filepath.Dir(path))
+			addFileForLanguage(scan, "go", path)
+		case ".php":
+			addDirForLanguage(scan, dirCache, "php", filepath.Dir(path))
+			addFileForLanguage(scan, "php", path)
+		case ".py":
+			addDirForLanguage(scan, dirCache, "python", filepath.Dir(path))
+			addFileForLanguage(scan, "python", path)
+		case ".html", ".htm":
+			addDirForLanguage(scan, dirCache, "html", filepath.Dir(path))
+			addFileForLanguage(scan, "html", path)
+		case ".md":
+			scan.DocFiles = append(scan.DocFiles, path)
+		default:
+			// ignored
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return scan, nil
+}
+
+func (s *workspaceScan) fingerprint(language string) string {
+	h := fnv.New64a()
+	lang := strings.ToLower(language)
+	fmt.Fprintf(h, "%s|%d|%d", lang, s.TotalFiles, len(s.DocFiles))
+	dirs := append([]string(nil), s.LanguageDirs[lang]...)
+	sort.Strings(dirs)
+	for _, dir := range dirs {
+		h.Write([]byte(dir))
+		h.Write([]byte("|"))
+	}
+	docs := append([]string(nil), s.DocFiles...)
+	sort.Strings(docs)
+	for _, doc := range docs {
+		h.Write([]byte(doc))
+		h.Write([]byte("|"))
+	}
+	return fmt.Sprintf("%x", h.Sum64())
+}
+
+func (m *Manager) fingerprintKey(info *Info, language string) string {
+	return info.ID + "-" + strings.ToLower(language)
+}
+
+func (m *Manager) recordFingerprint(info *Info, language string, scan *workspaceScan) {
+	if scan == nil {
+		return
+	}
+	fp := scan.fingerprint(language)
+	key := m.fingerprintKey(info, language)
+	m.scanMu.Lock()
+	if m.scanFingerprints == nil {
+		m.scanFingerprints = make(map[string]string)
+	}
+	m.scanFingerprints[key] = fp
+	m.scanMu.Unlock()
+}
+
+// NeedsReindex rescans the workspace and determines if tracked files changed for the language.
+// Returns true when changes are detected or no previous fingerprint exists.
+func (m *Manager) NeedsReindex(info *Info, language string) (bool, error) {
+	scan, err := m.scanWorkspace(info)
+	if err != nil {
+		return false, err
+	}
+	fp := scan.fingerprint(language)
+	key := m.fingerprintKey(info, language)
+	m.scanMu.RLock()
+	prev := m.scanFingerprints[key]
+	m.scanMu.RUnlock()
+	if prev == "" {
+		return true, nil
+	}
+	return prev != fp, nil
+}

--- a/internal/workspace/testing_helpers.go
+++ b/internal/workspace/testing_helpers.go
@@ -1,14 +1,21 @@
 package workspace
 
 import (
+	"path/filepath"
+
 	"github.com/doITmagic/rag-code-mcp/internal/memory"
 )
 
-// NewManagerForTest creates a Manager with a pre-configured cache for testing.
+// NewManagerForTest creates a Manager with a pre-configured cache and registry for testing.
 // This avoids needing real Qdrant, LLM, or config dependencies in unit tests.
-func NewManagerForTest(cache *Cache) *Manager {
+func NewManagerForTest(cache *Cache, registryDir string) *Manager {
+	regPath := ""
+	if registryDir != "" {
+		regPath = filepath.Join(registryDir, "workspaces.json")
+	}
 	return &Manager{
 		cache:    cache,
+		registry: NewRegistry(regPath),
 		memories: make(map[string]memory.LongTermMemory),
 	}
 }

--- a/internal/workspace/testing_helpers.go
+++ b/internal/workspace/testing_helpers.go
@@ -1,0 +1,14 @@
+package workspace
+
+import (
+	"github.com/doITmagic/rag-code-mcp/internal/memory"
+)
+
+// NewManagerForTest creates a Manager with a pre-configured cache for testing.
+// This avoids needing real Qdrant, LLM, or config dependencies in unit tests.
+func NewManagerForTest(cache *Cache) *Manager {
+	return &Manager{
+		cache:    cache,
+		memories: make(map[string]memory.LongTermMemory),
+	}
+}


### PR DESCRIPTION
## Description

This PR improves workspace root detection by centralizing default detection markers and adding explicit support for `.ragcode` as a valid workspace root marker.

Changes included:
- Added `DefaultWorkspaceDetectionMarkers` in `internal/config/config.go`.
- Switched default config marker initialization to use the centralized list in `internal/config/loader.go`.
- Switched workspace detector defaults to use the same centralized list in `internal/workspace/detector.go`.
- Updated IDE rule root resolution in `cmd/rag-code-mcp/main.go` to use centralized markers and include `AGENTS.md` / `CLAUDE.md` in the checked targets.

Motivation/context:
- Marker definitions were duplicated across components, which could cause drift and inconsistent root detection.
- This keeps behavior consistent and improves detection in repositories that use `.ragcode`.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code with `go fmt ./...`
- [ ] I have run tests `go test ./...` and they pass
- [ ] I have verified integration with Ollama/Qdrant (if applicable)
- [ ] I have updated the documentation accordingly

## Additional notes

- Commit: `a61d64ea705b668ac644baf3eb258af6a9f1d8e9`
- Scope intentionally excludes branch-aware invalidation and resolver metadata redesign.
