### PR TITLE
fix: address PR 25 review comments

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -127,7 +127,7 @@ Please use the 'rag_index_workspace' tool on this project.
 | "Ollama model not found" | Run `ollama pull qwen3-embedding:0.6b` |
 | IDE doesn't see RagCode | Re-run `./rag-code-install -skip-build` |
 
-For more help, see [Troubleshooting Guide](./docs/TROUBLESHOOTING.md) or open an [Issue](https://github.com/doITmagic/rag-code-mcp/issues).
+For more help, see the [README](./README.md) or open an [Issue](https://github.com/doITmagic/rag-code-mcp/issues).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ First query triggers background indexing. Subsequent queries are instant.
 | [🛠️ MCP Tools](#️-11-powerful-mcp-tools) | All 11 tools explained |
 | [🌐 Supported Languages](#-multi-language-code-intelligence) | Go, PHP, Python support |
 | [💻 IDE Integration](#-ide-integration) | Windsurf, Cursor, VS Code, Claude |
-| [⚙️ Configuration](./docs/CONFIGURATION.md) | Advanced settings, models, env vars |
-| [🐛 Troubleshooting](./docs/TROUBLESHOOTING.md) | Common issues and solutions |
+| [⚙️ Configuration](#-configuration) | Advanced settings, models, env vars |
+| [🐛 Troubleshooting](#-troubleshooting) | Common issues and solutions |
 | [📚 Documentation](#-documentation) | All guides and references |
 
 ---
@@ -253,7 +253,7 @@ RagCode works with all major AI-powered IDEs:
 | **GPU** | NVIDIA 8GB+ VRAM | Significantly speeds up Ollama (optional) |
 | **Disk** | 20 GB SSD | Faster indexing and search |
 
-📖 **[Full Requirements →](./docs/CONFIGURATION.md#-system-requirements)**
+📖 **[Full Requirements →](#-system-requirements)**
 
 ---
 
@@ -264,8 +264,8 @@ RagCode works with all major AI-powered IDEs:
 - **[IDE Setup](./docs/IDE-SETUP.md)** - Manual IDE configuration
 
 ### Configuration & Operations
-- **[Configuration Guide](./docs/CONFIGURATION.md)** - Models, env vars, advanced settings
-- **[Troubleshooting](./docs/TROUBLESHOOTING.md)** - Common issues and solutions
+- **[Configuration Guide](#-configuration)** - Models, env vars, advanced settings
+- **[Troubleshooting](#-troubleshooting)** - Common issues and solutions
 - **[Docker Setup](./docs/docker-setup.md)** - Docker configuration details
 
 ### Language Analyzers

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ First query triggers background indexing. Subsequent queries are instant.
 | [🛠️ MCP Tools](#️-11-powerful-mcp-tools) | All 11 tools explained |
 | [🌐 Supported Languages](#-multi-language-code-intelligence) | Go, PHP, Python support |
 | [💻 IDE Integration](#-ide-integration) | Windsurf, Cursor, VS Code, Claude |
-| [⚙️ Configuration](#-configuration) | Advanced settings, models, env vars |
-| [🐛 Troubleshooting](#-troubleshooting) | Common issues and solutions |
+| [⚙️ Configuration](./docs/configuration.md) | Advanced settings, models, env vars |
+| [🐛 Troubleshooting](./docs/troubleshooting.md) | Common issues and solutions |
 | [📚 Documentation](#-documentation) | All guides and references |
 
 ---
@@ -264,8 +264,8 @@ RagCode works with all major AI-powered IDEs:
 - **[IDE Setup](./docs/IDE-SETUP.md)** - Manual IDE configuration
 
 ### Configuration & Operations
-- **[Configuration Guide](#-configuration)** - Models, env vars, advanced settings
-- **[Troubleshooting](#-troubleshooting)** - Common issues and solutions
+- **[Configuration Guide](./docs/configuration.md)** - Models, env vars, advanced settings
+- **[Troubleshooting](./docs/troubleshooting.md)** - Common issues and solutions
 - **[Docker Setup](./docs/docker-setup.md)** - Docker configuration details
 
 ### Language Analyzers

--- a/cmd/sse-client-test/main.go
+++ b/cmd/sse-client-test/main.go
@@ -1,6 +1,7 @@
-// cmd/sse-client-test is a manual test client for the RagCode MCP server.
-// It uses the Streamable HTTP (stateless) transport: POST /mcp.
-// No SSE stream management, no sessionid — just plain JSON-RPC over HTTP.
+// cmd/sse-client-test is a manual HTTP MCP client for the RagCode MCP server.
+// It primarily tests the Streamable HTTP (stateless) transport via POST /mcp
+// and only does best-effort parsing of SSE-style `data:` lines in responses.
+// NOTE: The directory/binary name is legacy; a more accurate name would be `mcp-http-client-test`.
 package main
 
 import (

--- a/internal/config/README.md
+++ b/internal/config/README.md
@@ -22,8 +22,6 @@ The root configuration structure, containing sub-sections for:
 ```go
 import "github.com/doITmagic/rag-code-mcp/internal/config"
 
-// Load will look for config.yaml in the execution directory
-// and apply environment overrides.
 // Load reads configuration from the given path (e.g. ./config.yaml)
 // and applies environment overrides.
 cfg, err := config.Load("./config.yaml")

--- a/internal/config/README.md
+++ b/internal/config/README.md
@@ -24,7 +24,9 @@ import "github.com/doITmagic/rag-code-mcp/internal/config"
 
 // Load will look for config.yaml in the execution directory
 // and apply environment overrides.
-cfg, err := config.Load()
+// Load reads configuration from the given path (e.g. ./config.yaml)
+// and applies environment overrides.
+cfg, err := config.Load("./config.yaml")
 if err != nil {
     log.Fatalf("Failed to load config: %v", err)
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -263,8 +263,7 @@ func MigrateEmbeddingModel(cfg *Config) bool {
 			log.Printf("║  Vector spaces differ between models — old results will be   ║")
 			log.Printf("║  garbage until you re-index.                                 ║")
 			log.Printf("║                                                              ║")
-			log.Printf("║  Run: rag_index_workspace with force_reindex: true           ║")
-			log.Printf("║  Or:  rag_index_workspace with recreate: true                ║")
+			log.Printf("║  Run: rag_index_workspace with recreate: true                ║")
 			log.Printf("╚══════════════════════════════════════════════════════════════╝")
 
 			cfg.LLM.OllamaEmbed = newStableModel

--- a/internal/service/search/README.md
+++ b/internal/service/search/README.md
@@ -1,6 +1,6 @@
 # Search Service
 
-The `search` package implements the core discovery logic of RagCode. It abstraction the complexities of vector similarity and lexical matching into a simple interface.
+The `search` package implements the core discovery logic of RagCode. It abstracts the complexities of vector similarity and lexical matching into a simple interface.
 
 ## Search Strategies
 

--- a/internal/service/search/search_test.go
+++ b/internal/service/search/search_test.go
@@ -13,187 +13,187 @@ import (
 // ─── Mocks ─────────────────────────────────────────────────────────────────────
 
 type mockEmbedder struct {
-embedCount int32
-result     []float64
-err        error
+	embedCount int32
+	result     []float64
+	err        error
 }
 
 func (m *mockEmbedder) Embed(_ context.Context, _ string) ([]float64, error) {
-atomic.AddInt32(&m.embedCount, 1)
-if m.err != nil {
-return nil, m.err
-}
-if m.result != nil {
-return m.result, nil
-}
-return []float64{0.1, 0.2, 0.3}, nil
+	atomic.AddInt32(&m.embedCount, 1)
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.result != nil {
+		return m.result, nil
+	}
+	return []float64{0.1, 0.2, 0.3}, nil
 }
 func (m *mockEmbedder) Generate(_ context.Context, _ string, _ ...llm.GenerateOption) (string, error) {
-return "", nil
+	return "", nil
 }
 func (m *mockEmbedder) GenerateStream(_ context.Context, _ string, _ ...llm.GenerateOption) (<-chan string, <-chan error) {
-return nil, nil
+	return nil, nil
 }
-func (m *mockEmbedder) Name() string              { return "mock" }
+func (m *mockEmbedder) Name() string                  { return "mock" }
 func (m *mockEmbedder) GetEmbeddingDimension() uint64 { return 3 }
 
 // mockVectorStore tracks which store methods are called.
 type mockVectorStore struct {
-storage.VectorStore // embed to satisfy non-overridden methods
-searchCodeOnlyCalls int
-exactSearchCalls    int
-searchCalls         int
-exactSearchResults  []storage.SearchResult
-exactSearchErr      error
-searchCodeOnlyErr   error
+	storage.VectorStore // embed to satisfy non-overridden methods
+	searchCodeOnlyCalls int
+	exactSearchCalls    int
+	searchCalls         int
+	exactSearchResults  []storage.SearchResult
+	exactSearchErr      error
+	searchCodeOnlyErr   error
 }
 
 func (m *mockVectorStore) SearchCodeOnly(_ context.Context, _ string, _ storage.SearchQuery) ([]storage.SearchResult, error) {
-m.searchCodeOnlyCalls++
-return nil, m.searchCodeOnlyErr
+	m.searchCodeOnlyCalls++
+	return nil, m.searchCodeOnlyErr
 }
 
 func (m *mockVectorStore) Search(_ context.Context, _ string, _ storage.SearchQuery) ([]storage.SearchResult, error) {
-m.searchCalls++
-return nil, nil
+	m.searchCalls++
+	return nil, nil
 }
 
 func (m *mockVectorStore) ExactSearch(_ context.Context, _ string, _ map[string]interface{}, _ int) ([]storage.SearchResult, error) {
-m.exactSearchCalls++
-return m.exactSearchResults, m.exactSearchErr
+	m.exactSearchCalls++
+	return m.exactSearchResults, m.exactSearchErr
 }
 
 func (m *mockVectorStore) CollectionExists(_ context.Context, _ string) (bool, error) {
-return true, nil
+	return true, nil
 }
 
 // ─── Tests ─────────────────────────────────────────────────────────────────────
 
 // TestEmbedQueryConvertsToFloat32 ensures EmbedQuery correctly converts []float64 -> []float32.
 func TestEmbedQueryConvertsToFloat32(t *testing.T) {
-emb := &mockEmbedder{result: []float64{1.0, 2.5, 3.75}}
-svc := NewService(emb, &mockVectorStore{})
+	emb := &mockEmbedder{result: []float64{1.0, 2.5, 3.75}}
+	svc := NewService(emb, &mockVectorStore{})
 
-vec, err := svc.EmbedQuery(context.Background(), "test query")
-if err != nil {
-t.Fatalf("unexpected error: %v", err)
-}
-if len(vec) != 3 {
-t.Fatalf("expected 3 floats, got %d", len(vec))
-}
-if vec[0] != float32(1.0) || vec[1] != float32(2.5) || vec[2] != float32(3.75) {
-t.Fatalf("float conversion incorrect: %v", vec)
-}
-if atomic.LoadInt32(&emb.embedCount) != 1 {
-t.Fatalf("expected 1 embed call, got %d", emb.embedCount)
-}
+	vec, err := svc.EmbedQuery(context.Background(), "test query")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vec) != 3 {
+		t.Fatalf("expected 3 floats, got %d", len(vec))
+	}
+	if vec[0] != float32(1.0) || vec[1] != float32(2.5) || vec[2] != float32(3.75) {
+		t.Fatalf("float conversion incorrect: %v", vec)
+	}
+	if atomic.LoadInt32(&emb.embedCount) != 1 {
+		t.Fatalf("expected 1 embed call, got %d", emb.embedCount)
+	}
 }
 
 // TestEmbedQueryPropagatesError ensures errors from the embedder bubble up.
 func TestEmbedQueryPropagatesError(t *testing.T) {
-emb := &mockEmbedder{err: errors.New("ollama down")}
-svc := NewService(emb, &mockVectorStore{})
+	emb := &mockEmbedder{err: errors.New("ollama down")}
+	svc := NewService(emb, &mockVectorStore{})
 
-_, err := svc.EmbedQuery(context.Background(), "query")
-if err == nil {
-t.Fatal("expected error when embedder fails")
-}
-if !errContains(err, "ollama down") {
-t.Fatalf("expected original error message in wrapped error, got: %v", err)
-}
+	_, err := svc.EmbedQuery(context.Background(), "query")
+	if err == nil {
+		t.Fatal("expected error when embedder fails")
+	}
+	if !errContains(err, "ollama down") {
+		t.Fatalf("expected original error message in wrapped error, got: %v", err)
+	}
 }
 
 // TestSearchCodeOnlyCallsEmbedExactlyOnce ensures SearchCodeOnly embeds once
 // and then delegates to the store (no double-embedding).
 func TestSearchCodeOnlyCallsEmbedExactlyOnce(t *testing.T) {
-emb := &mockEmbedder{}
-store := &mockVectorStore{}
-svc := NewService(emb, store)
+	emb := &mockEmbedder{}
+	store := &mockVectorStore{}
+	svc := NewService(emb, store)
 
-_, _ = svc.SearchCodeOnly(context.Background(), "col", "find function", 10)
+	_, _ = svc.SearchCodeOnly(context.Background(), "col", "find function", 10)
 
-if atomic.LoadInt32(&emb.embedCount) != 1 {
-t.Fatalf("expected exactly 1 embed call, got %d", emb.embedCount)
-}
-if store.searchCodeOnlyCalls != 1 {
-t.Fatalf("expected 1 store.SearchCodeOnly call, got %d", store.searchCodeOnlyCalls)
-}
+	if atomic.LoadInt32(&emb.embedCount) != 1 {
+		t.Fatalf("expected exactly 1 embed call, got %d", emb.embedCount)
+	}
+	if store.searchCodeOnlyCalls != 1 {
+		t.Fatalf("expected 1 store.SearchCodeOnly call, got %d", store.searchCodeOnlyCalls)
+	}
 }
 
 // TestSearchCodeWithVectorSkipsEmbedder verifies that SearchCodeWithVector
 // does NOT call the embedder at all -- it uses the pre-computed vector directly.
 func TestSearchCodeWithVectorSkipsEmbedder(t *testing.T) {
-emb := &mockEmbedder{}
-store := &mockVectorStore{}
-svc := NewService(emb, store)
+	emb := &mockEmbedder{}
+	store := &mockVectorStore{}
+	svc := NewService(emb, store)
 
-precomputed := []float32{0.1, 0.2, 0.3}
-_, _ = svc.SearchCodeWithVector(context.Background(), "col", precomputed, 5)
+	precomputed := []float32{0.1, 0.2, 0.3}
+	_, _ = svc.SearchCodeWithVector(context.Background(), "col", precomputed, 5)
 
-if atomic.LoadInt32(&emb.embedCount) != 0 {
-t.Fatalf("SearchCodeWithVector must NOT call embedder, got %d calls", emb.embedCount)
-}
-if store.searchCodeOnlyCalls != 1 {
-t.Fatalf("expected 1 store.SearchCodeOnly call, got %d", store.searchCodeOnlyCalls)
-}
+	if atomic.LoadInt32(&emb.embedCount) != 0 {
+		t.Fatalf("SearchCodeWithVector must NOT call embedder, got %d calls", emb.embedCount)
+	}
+	if store.searchCodeOnlyCalls != 1 {
+		t.Fatalf("expected 1 store.SearchCodeOnly call, got %d", store.searchCodeOnlyCalls)
+	}
 }
 
 // TestExactSearchDelegatesToStoreExactSearch is the core correctness test:
 // ExactSearch must call store.ExactSearch (Scroll path) and must NOT call
 // store.Search (which would use a dummy vector and traverse HNSW).
 func TestExactSearchDelegatesToStoreExactSearch(t *testing.T) {
-emb := &mockEmbedder{}
-expected := []storage.SearchResult{
-{Score: 1.0, Point: storage.Point{ID: "x1", Payload: map[string]interface{}{"name": "MyFunc"}}},
-}
-store := &mockVectorStore{exactSearchResults: expected}
-svc := NewService(emb, store)
+	emb := &mockEmbedder{}
+	expected := []storage.SearchResult{
+		{Score: 1.0, Point: storage.Point{ID: "x1", Payload: map[string]interface{}{"name": "MyFunc"}}},
+	}
+	store := &mockVectorStore{exactSearchResults: expected}
+	svc := NewService(emb, store)
 
-results, err := svc.ExactSearch(context.Background(), "col", map[string]interface{}{"name": "MyFunc"}, 5)
-if err != nil {
-t.Fatalf("unexpected error: %v", err)
-}
+	results, err := svc.ExactSearch(context.Background(), "col", map[string]interface{}{"name": "MyFunc"}, 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
-// Embedder must NOT be called at all
-if atomic.LoadInt32(&emb.embedCount) != 0 {
-t.Fatalf("ExactSearch must NOT call embedder, got %d calls", emb.embedCount)
-}
-// store.Search (HNSW path) must NOT be called
-if store.searchCalls != 0 {
-t.Fatalf("ExactSearch must NOT call store.Search, got %d calls", store.searchCalls)
-}
-// store.ExactSearch (Scroll path) must be called
-if store.exactSearchCalls != 1 {
-t.Fatalf("ExactSearch must call store.ExactSearch once, got %d calls", store.exactSearchCalls)
-}
-if len(results) != 1 || results[0].Point.ID != "x1" {
-t.Fatalf("unexpected results: %v", results)
-}
+	// Embedder must NOT be called at all
+	if atomic.LoadInt32(&emb.embedCount) != 0 {
+		t.Fatalf("ExactSearch must NOT call embedder, got %d calls", emb.embedCount)
+	}
+	// store.Search (HNSW path) must NOT be called
+	if store.searchCalls != 0 {
+		t.Fatalf("ExactSearch must NOT call store.Search, got %d calls", store.searchCalls)
+	}
+	// store.ExactSearch (Scroll path) must be called
+	if store.exactSearchCalls != 1 {
+		t.Fatalf("ExactSearch must call store.ExactSearch once, got %d calls", store.exactSearchCalls)
+	}
+	if len(results) != 1 || results[0].Point.ID != "x1" {
+		t.Fatalf("unexpected results: %v", results)
+	}
 }
 
 // TestExactSearchPropagatesStoreError verifies errors from the store bubble up.
 func TestExactSearchPropagatesStoreError(t *testing.T) {
-store := &mockVectorStore{exactSearchErr: errors.New("qdrant scroll failed")}
-svc := NewService(&mockEmbedder{}, store)
+	store := &mockVectorStore{exactSearchErr: errors.New("qdrant scroll failed")}
+	svc := NewService(&mockEmbedder{}, store)
 
-_, err := svc.ExactSearch(context.Background(), "col", map[string]interface{}{"name": "X"}, 5)
-if err == nil {
-t.Fatal("expected error when store returns error")
-}
-if !errContains(err, "qdrant scroll failed") {
-t.Fatalf("expected store error wrapped, got: %v", err)
-}
+	_, err := svc.ExactSearch(context.Background(), "col", map[string]interface{}{"name": "X"}, 5)
+	if err == nil {
+		t.Fatal("expected error when store returns error")
+	}
+	if !errContains(err, "qdrant scroll failed") {
+		t.Fatalf("expected store error wrapped, got: %v", err)
+	}
 }
 
 func errContains(err error, sub string) bool {
-if err == nil {
-return false
-}
-s := err.Error()
-for i := 0; i <= len(s)-len(sub); i++ {
-if s[i:i+len(sub)] == sub {
-return true
-}
-}
-return false
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/service/tools/README.md
+++ b/internal/service/tools/README.md
@@ -30,11 +30,11 @@ A deterministic replacement for the legacy `find_implementations` tool. Instead 
 ### Query Mechanism
 - **Exact DB Match**: It completely bypasses the LLM Embedder. It uses the `ExactSearch` capability to query Qdrant directly using a strict filter on the `Relations` array:
   ```json
-  { "Relations[].target_name": "SymbolName" }
+  { "relations[].target_name": "SymbolName" }
   ```
 
 ### How it Works & Important Points
-- **100% Determinist**: Because the indexer parses the AST and maps out exactly what function calls what, this tool queries those explicit edges.
+- **100% Deterministic**: Because the indexer parses the AST and maps out exactly what function calls what, this tool queries those explicit edges.
 - **Zero Hallucination**: You get exactly the files and line numbers where `SymbolName` is invoked, instantiated, or implemented.
 - **Telemetry**: Calculates the exact bytes of the snippet returned versus the full file sizes to demonstrate the RAG context savings.
 
@@ -77,7 +77,7 @@ Instead of dumping an entire 2000-line file into the AI's context window, this t
 Every new tool added to this package MUST adhere to the following lifecycle:
 
 1. **Implement Tool Interface**: Register its name, description, and input schema securely.
-2. **Require `file_path`**: Always request a `file_path` or `workspace_root` from the AI to ensure multi-root or polyglot workspaces resolve to the correct index collection (`ragcode-<ws_id>-<lang>`).
+2. **Prefer `file_path`**: Prefer requesting a `file_path` or `workspace_root` from the AI to ensure multi-root or polyglot workspaces resolve to the correct index collection (`ragcode-<ws_id>-<lang>`). If omitted, the server MAY fall back to the last active workspace when it can safely resolve it, but this can be less reliable and slower.
 3. **Resolve Engine Context**: Call `t.engine.DetectContext(ctx, filePath)` to guarantee the tool executes within the boundaries of the correct Git branch and repository.
 4. **Use `ExactSearch` vs `Search`**: If you are looking for specific metadata (like a package name or an AST relation), use `searchSvc.ExactSearch`. If you are looking for conceptual ideas ("how do I authenticate"), use `searchSvc.Search`.
 5. **Standardized Response**: All tools MUST return their data wrapped in a JSON `ToolResponse`. This includes the core message, structured `Data`, and `ContextMetadata` (including `Telemetry` and `DetectionSource`).

--- a/internal/service/tools/doc_call_hierarchy.md
+++ b/internal/service/tools/doc_call_hierarchy.md
@@ -10,7 +10,7 @@ This tool operates as a stateful, recursive orchestrator over the **Code Graph R
 
 1. **Incoming Mode (`direction="incoming"`)**:
    * Identifies all "Caller" nodes by querying the database for any chunk where the `Relations` array contains a `target_name` matching the current symbol.
-   * DB Filter: `{ "Relations[].target_name": "<SymbolName>" }`
+   * DB Filter: `{ "relations[].target_name": "<SymbolName>" }`
    
 2. **Outgoing Mode (`direction="outgoing"`)**:
    * Identifies "Callee" nodes by searching for the symbol itself and extracting all `target_name` entries from its own `Relations` payload metadata.

--- a/internal/service/tools/doc_find_usages.md
+++ b/internal/service/tools/doc_find_usages.md
@@ -15,7 +15,7 @@ It completely **bypasses the Semantic Embedder (LLM)** and issues an Exact Match
 
 ```json
 {
-  "Relations[].target_name": "<SymbolName>"
+  "relations[].target_name": "<SymbolName>"
 }
 ```
 

--- a/internal/service/tools/find_usages.go
+++ b/internal/service/tools/find_usages.go
@@ -223,10 +223,7 @@ func (t *FindUsagesTool) Execute(ctx context.Context, args map[string]interface{
 		}
 	}
 
-	// Add markdown payload as well under a human readable format
-	// actually, the standard pattern for tools in rag-code-mcp:
-	// To return string so the AI can read it, we change ToolResponse struct or just return the JSON string.
-	// We'll construct a generic Map to marshal it all manually just like rag_search_code.
+	// Wrap the formatted usages and metadata in the standard ToolResponse format.
 
 	resp := ToolResponse{
 		Status:  "success",

--- a/internal/service/tools/index_workspace.go
+++ b/internal/service/tools/index_workspace.go
@@ -33,8 +33,9 @@ func (t *IndexWorkspaceTool) Description() string {
 }
 
 type IndexWorkspaceInput struct {
-	FilePath string `json:"file_path,omitempty"`
-	Recreate bool   `json:"recreate,omitempty"`
+	FilePath           string `json:"file_path,omitempty"`
+	Recreate           bool   `json:"recreate,omitempty"`
+	IncludeRuntimeInfo bool   `json:"include_runtime_info,omitempty"`
 }
 
 func (t *IndexWorkspaceTool) Register(server *mcp.Server) {
@@ -43,8 +44,9 @@ func (t *IndexWorkspaceTool) Register(server *mcp.Server) {
 		Description: t.Description(),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input IndexWorkspaceInput) (*mcp.CallToolResult, any, error) {
 		args := map[string]interface{}{
-			"file_path": input.FilePath,
-			"recreate":  input.Recreate,
+			"file_path":            input.FilePath,
+			"recreate":             input.Recreate,
+			"include_runtime_info": input.IncludeRuntimeInfo,
 		}
 
 		start := time.Now()
@@ -83,7 +85,7 @@ func (t *IndexWorkspaceTool) Execute(ctx context.Context, params map[string]inte
 
 	response := ToolResponse{
 		Status:  "indexing_started",
-		Message: fmt.Sprintf("🚀 Indexing started for workspace '%s'. The process is running in the background. You can use search_code immediately - results will appear as indexing progresses.", wctx.Root),
+		Message: fmt.Sprintf("🚀 Indexing started for workspace '%s'. The process is running in the background. You can use rag_search (or rag_search_code) immediately - results will appear as indexing progresses.", wctx.Root),
 		Context: ContextMetadata{
 			WorkspaceRoot:   wctx.Root,
 			DetectionSource: wctx.DetectionSource,
@@ -98,8 +100,11 @@ func (t *IndexWorkspaceTool) Execute(ctx context.Context, params map[string]inte
 		}
 	}
 
-	data := map[string]interface{}{
-		"runtime": map[string]interface{}{
+	data := map[string]interface{}{}
+
+	includeRuntimeInfo, _ := params["include_runtime_info"].(bool)
+	if includeRuntimeInfo {
+		data["runtime"] = map[string]interface{}{
 			"pid":                os.Getpid(),
 			"executable_path":    exePath,
 			"binary_modified_at": binModTime,
@@ -111,7 +116,7 @@ func (t *IndexWorkspaceTool) Execute(ctx context.Context, params map[string]inte
 				"commit":  serverCommit,
 				"date":    serverDate,
 			},
-		},
+		}
 	}
 
 	// Include current indexing progress so the AI knows how many files are left

--- a/internal/service/tools/index_workspace.go
+++ b/internal/service/tools/index_workspace.go
@@ -92,18 +92,18 @@ func (t *IndexWorkspaceTool) Execute(ctx context.Context, params map[string]inte
 		},
 	}
 
-	exePath, _ := os.Executable()
-	binModTime := "unknown"
-	if exePath != "" {
-		if stat, statErr := os.Stat(exePath); statErr == nil {
-			binModTime = stat.ModTime().Format(time.RFC3339)
-		}
-	}
-
 	data := map[string]interface{}{}
 
 	includeRuntimeInfo, _ := params["include_runtime_info"].(bool)
 	if includeRuntimeInfo {
+		exePath, _ := os.Executable()
+		binModTime := "unknown"
+		if exePath != "" {
+			if stat, statErr := os.Stat(exePath); statErr == nil {
+				binModTime = stat.ModTime().Format(time.RFC3339)
+			}
+		}
+
 		data["runtime"] = map[string]interface{}{
 			"pid":                os.Getpid(),
 			"executable_path":    exePath,

--- a/internal/service/tools/tests/find_usages_test.go
+++ b/internal/service/tools/tests/find_usages_test.go
@@ -49,8 +49,8 @@ var _ = Describe("FindUsagesTool", func() {
 			var resp tools.ToolResponse
 			Expect(json.Unmarshal([]byte(resJSON), &resp)).NotTo(HaveOccurred())
 
-			// Depending on whether auto-index is started or not, status could be indexing_started or indexing_required
-			// FindUsages auto-starts indexing if nothing is found and returns indexing_in_progress
+			// Depending on whether auto-index is started or not, status could be indexing_required or indexing_in_progress
+			// FindUsages auto-starts indexing if nothing is found and returns indexing_in_progress in that case
 			Expect(resp.Status).To(MatchRegexp("indexing_in_progress|indexing_required"))
 		})
 

--- a/internal/service/tools/tests/find_usages_test.go
+++ b/internal/service/tools/tests/find_usages_test.go
@@ -40,6 +40,20 @@ var _ = Describe("FindUsagesTool", func() {
 			Expect(resp.Error).To(ContainSubstring("symbol_name parameter is required"))
 		})
 
+		It("should return indexing_required if ErrNoCollectionsFound", func() {
+			mockStore.CollectionExistsFunc = func(ctx context.Context, name string) (bool, error) {
+				return false, nil
+			}
+			resJSON, err := tool.Execute(ctx, map[string]interface{}{"symbol_name": "GhostFunc", "file_path": "main.go"})
+			Expect(err).NotTo(HaveOccurred())
+			var resp tools.ToolResponse
+			Expect(json.Unmarshal([]byte(resJSON), &resp)).NotTo(HaveOccurred())
+
+			// Depending on whether auto-index is started or not, status could be indexing_started or indexing_required
+			// FindUsages auto-starts indexing if nothing is found and returns indexing_in_progress
+			Expect(resp.Status).To(MatchRegexp("indexing_in_progress|indexing_required"))
+		})
+
 		It("should return no_results if no usages are found", func() {
 			mockStore.SearchFunc = func(ctx context.Context, col string, q storage.SearchQuery) ([]storage.SearchResult, error) {
 				return []storage.SearchResult{}, nil


### PR DESCRIPTION
This commit addresses the review comments from PR #25:
- Removed references to the removed `force_reindex` flag.
- Updated the tool reference in the index_workspace output.
- Fixed documentation issues, broken links, typos, and grammar.
- Made the sensitive runtime information in `rag_index_workspace` optional behind an `include_runtime_info` flag.
- Addressed missing unit tests for `FindUsagesTool`.
- Fixed `gofmt` in `search_test.go` and removed a confusing development comment.

---
*PR created automatically by Jules for task [2835981728704916877](https://jules.google.com/task/2835981728704916877) started by @doITmagic*