### PR TITLE
feat: Single Instance Proxy Architecture & Non-blocking Search Engine

### DIFF
--- a/cmd/rag-code-mcp/main.go
+++ b/cmd/rag-code-mcp/main.go
@@ -103,6 +103,14 @@ func main() {
 		if takeOver {
 			logger.Instance.Info("Our version %s > master %s → taking over as new master", Version, masterVersion)
 			proxy.KillProcessOnPort(*httpPort)
+			// Verify the port is actually free before proceeding as master.
+			// If kill failed (missing lsof, permissions, stubborn process), the HTTP
+			// server would fail to bind silently. Instead, fall back to proxy mode.
+			if proxy.PortIsOccupied(*httpPort) {
+				logger.Instance.Warn("Port %d still occupied after kill attempt — falling back to proxy mode", *httpPort)
+				proxy.RunProxyMode(*httpPort)
+				return
+			}
 			// Fall through to normal master startup below.
 		} else {
 			// Enter proxy mode — no heavy initialization.

--- a/cmd/rag-code-mcp/main.go
+++ b/cmd/rag-code-mcp/main.go
@@ -38,7 +38,7 @@ import (
 )
 
 var (
-	Version = "2.1.51"
+	Version = "2.1.52"
 	Commit  = "none"
 	Date    = "24.10.2025"
 )

--- a/cmd/rag-code-mcp/main.go
+++ b/cmd/rag-code-mcp/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/doITmagic/rag-code-mcp/internal/config"
 	"github.com/doITmagic/rag-code-mcp/internal/healthcheck"
 	"github.com/doITmagic/rag-code-mcp/internal/logger"
+	"github.com/doITmagic/rag-code-mcp/internal/proxy"
 	"github.com/doITmagic/rag-code-mcp/internal/service/engine"
 	"github.com/doITmagic/rag-code-mcp/internal/service/search"
 	"github.com/doITmagic/rag-code-mcp/internal/service/tools"
@@ -37,7 +38,7 @@ import (
 )
 
 var (
-	Version = "2.1.50"
+	Version = "2.1.51"
 	Commit  = "none"
 	Date    = "24.10.2025"
 )
@@ -73,6 +74,44 @@ func main() {
 	if *versionFlag {
 		fmt.Printf("RagCode MCP  version=%s  commit=%s  date=%s\n", Version, Commit, Date)
 		os.Exit(0)
+	}
+
+	// ── Single-instance enforcement ──────────────────────────────────────
+	// If the HTTP port is already occupied by another rag-code-mcp instance,
+	// we decide our role based on version comparison:
+	//   • Our version is newer  → kill the old master, become the new master.
+	//   • Our version is same/older → enter lightweight proxy mode (Stdio↔HTTP).
+	//
+	// This ensures only ONE heavy process (Qdrant, Ollama, indexer) runs at
+	// any time, while multiple IDEs can still use Stdio transport seamlessly.
+	if *httpPort > 0 && proxy.PortIsOccupied(*httpPort) {
+		masterVersion := proxy.QueryMasterVersion(*httpPort)
+		if masterVersion != "" {
+			logger.Instance.Info("Detected existing master on port %d (version=%s, our version=%s)", *httpPort, masterVersion, Version)
+		} else {
+			logger.Instance.Info("Detected occupied port %d but could not query master version", *httpPort)
+		}
+
+		// Compare versions using semver: take over only if strictly newer.
+		takeOver := false
+		if masterVersion != "" {
+			current, errC := semver.NewVersion(Version)
+			master, errM := semver.NewVersion(masterVersion)
+			if errC == nil && errM == nil && current.GreaterThan(master) {
+				takeOver = true
+			}
+		}
+
+		if takeOver {
+			logger.Instance.Info("Our version %s > master %s → taking over as new master", Version, masterVersion)
+			proxy.KillProcessOnPort(*httpPort)
+			// Fall through to normal master startup below.
+		} else {
+			// Enter proxy mode — no heavy initialization.
+			logger.Instance.Info("Entering proxy mode (master version=%s, our version=%s)", masterVersion, Version)
+			proxy.RunProxyMode(*httpPort)
+			return
+		}
 	}
 
 	// Config — resolve bare filenames (e.g. "config.yaml") relative to the

--- a/cmd/rag-code-mcp/main.go
+++ b/cmd/rag-code-mcp/main.go
@@ -38,7 +38,7 @@ import (
 )
 
 var (
-	Version = "2.1.52"
+	Version = "2.1.53"
 	Commit  = "none"
 	Date    = "24.10.2025"
 )
@@ -89,17 +89,15 @@ func main() {
 		if masterVersion != "" {
 			logger.Instance.Info("Detected existing master on port %d (version=%s, our version=%s)", *httpPort, masterVersion, Version)
 		} else {
-			logger.Instance.Info("Detected occupied port %d but could not query master version", *httpPort)
+			log.Fatalf("Port %d is occupied but could not verify it corresponds to a rag-code-mcp master. Failing fast to avoid proxying to an unknown service.", *httpPort)
 		}
 
 		// Compare versions using semver: take over only if strictly newer.
 		takeOver := false
-		if masterVersion != "" {
-			current, errC := semver.NewVersion(Version)
-			master, errM := semver.NewVersion(masterVersion)
-			if errC == nil && errM == nil && current.GreaterThan(master) {
-				takeOver = true
-			}
+		current, errC := semver.NewVersion(Version)
+		master, errM := semver.NewVersion(masterVersion)
+		if errC == nil && errM == nil && current.GreaterThan(master) {
+			takeOver = true
 		}
 
 		if takeOver {

--- a/internal/proxy/portutil.go
+++ b/internal/proxy/portutil.go
@@ -99,6 +99,12 @@ func QueryMasterVersion(port int) string {
 	if !ok {
 		return ""
 	}
+	// Validate this is actually a RagCode instance, not another MCP server.
+	// Prevents misidentifying and killing unrelated services on the same port.
+	name, _ := serverInfo["name"].(string)
+	if name != "ragcode" {
+		return ""
+	}
 	version, _ := serverInfo["version"].(string)
 	return version
 }

--- a/internal/proxy/portutil.go
+++ b/internal/proxy/portutil.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os/exec"
@@ -62,10 +63,31 @@ func QueryMasterVersion(port int) string {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		return ""
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return ""
+	}
+
 	// Parse the response — may be direct JSON or SSE-wrapped.
 	var result map[string]any
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return ""
+	if err := json.Unmarshal(bodyBytes, &result); err != nil {
+		// Not direct JSON — try SSE extraction if Content-Type matches.
+		contentType := resp.Header.Get("Content-Type")
+		if strings.HasPrefix(contentType, "text/event-stream") {
+			payload := extractSSEPayload(bodyBytes)
+			if payload == nil {
+				return ""
+			}
+			if err := json.Unmarshal(payload, &result); err != nil {
+				return ""
+			}
+		} else {
+			return ""
+		}
 	}
 
 	// Navigate: result.serverInfo.version

--- a/internal/proxy/portutil.go
+++ b/internal/proxy/portutil.go
@@ -1,0 +1,137 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/doITmagic/rag-code-mcp/internal/logger"
+)
+
+// PortIsOccupied returns true if the given TCP port is already listening.
+func PortIsOccupied(port int) bool {
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 1*time.Second)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}
+
+// QueryMasterVersion sends an MCP initialize request to the running master
+// and returns its reported version string (e.g. "2.1.51").
+// Returns "" on any error (timeout, parse failure, etc.).
+func QueryMasterVersion(port int) string {
+	payload := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "version-check",
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-03-26",
+			"clientInfo": map[string]string{
+				"name":    "ragcode-proxy",
+				"version": "1.0.0",
+			},
+			"capabilities": map[string]any{},
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return ""
+	}
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/mcp", port)
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+
+	// Parse the response — may be direct JSON or SSE-wrapped.
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return ""
+	}
+
+	// Navigate: result.serverInfo.version
+	res, ok := result["result"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	serverInfo, ok := res["serverInfo"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	version, _ := serverInfo["version"].(string)
+	return version
+}
+
+// KillProcessOnPort finds the process listening on the given port and kills it.
+// On Linux/macOS uses lsof + kill; on Windows uses netstat + taskkill.
+// Waits up to 3 seconds for the port to become free.
+func KillProcessOnPort(port int) {
+	addr := fmt.Sprintf("%d", port)
+
+	if runtime.GOOS == "windows" {
+		// netstat -ano | findstr :3000 → extract PID → taskkill
+		out, err := exec.Command("cmd", "/C", fmt.Sprintf("netstat -ano | findstr :%s", addr)).Output()
+		if err == nil {
+			for _, line := range strings.Split(string(out), "\n") {
+				fields := strings.Fields(strings.TrimSpace(line))
+				if len(fields) >= 5 {
+					pid := fields[len(fields)-1]
+					_ = exec.Command("taskkill", "/F", "/PID", pid).Run()
+				}
+			}
+		}
+	} else {
+		// lsof -ti :3000 → kill each PID
+		out, err := exec.Command("lsof", "-ti", fmt.Sprintf(":%s", addr)).Output()
+		if err == nil {
+			for _, pid := range strings.Fields(string(out)) {
+				if pid != "" {
+					logger.Instance.Info("Killing old master process PID=%s on port %d", pid, port)
+					_ = exec.Command("kill", pid).Run()
+				}
+			}
+		}
+	}
+
+	// Wait for port to become free (max 3s)
+	for i := 0; i < 6; i++ {
+		if !PortIsOccupied(port) {
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	// Force kill if still occupied
+	if runtime.GOOS != "windows" {
+		out, err := exec.Command("lsof", "-ti", fmt.Sprintf(":%d", port)).Output()
+		if err == nil {
+			for _, pid := range strings.Fields(string(out)) {
+				if pid != "" {
+					logger.Instance.Warn("Force-killing stubborn process PID=%s on port %d", pid, port)
+					_ = exec.Command("kill", "-9", pid).Run()
+				}
+			}
+		}
+	}
+
+	time.Sleep(500 * time.Millisecond)
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1,0 +1,162 @@
+package proxy
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/doITmagic/rag-code-mcp/internal/logger"
+)
+
+// RunProxyMode runs a lightweight Stdio-to-HTTP proxy.
+// It reads newline-delimited JSON-RPC messages from stdin, forwards them
+// as HTTP POST requests to the master instance on the given port,
+// and writes the responses back to stdout.
+//
+// This function blocks until stdin is closed (EOF) or the context is cancelled.
+// It never returns under normal operation — the process exits when the IDE
+// closes the stdin pipe.
+func RunProxyMode(port int) {
+	logger.Instance.Info("Entering PROXY mode → forwarding Stdio to http://127.0.0.1:%d/mcp", port)
+
+	targetURL := fmt.Sprintf("http://127.0.0.1:%d/mcp", port)
+	client := &http.Client{Timeout: 5 * time.Minute} // long timeout for indexing operations
+
+	scanner := bufio.NewScanner(os.Stdin)
+	// MCP messages can be large (e.g. search results with full file contents).
+	// Default scanner buffer is 64KB; expand to 10MB.
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		resp, err := forwardToMaster(client, targetURL, []byte(line))
+		if err != nil {
+			// If master is unreachable, send a JSON-RPC error back to the IDE.
+			logger.Instance.Error("Proxy forward failed: %v", err)
+			writeErrorResponse(os.Stdout, line, err)
+			continue
+		}
+
+		// Write response as a single line to stdout (newline-delimited JSON).
+		resp = bytes.TrimRight(resp, "\n\r")
+		fmt.Fprintf(os.Stdout, "%s\n", resp)
+	}
+
+	if err := scanner.Err(); err != nil {
+		logger.Instance.Error("Proxy stdin read error: %v", err)
+	}
+
+	logger.Instance.Info("Proxy mode: stdin closed (EOF), shutting down")
+}
+
+// forwardToMaster sends a JSON-RPC message to the master's HTTP endpoint
+// and returns the response body.
+func forwardToMaster(client *http.Client, url string, message []byte) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(message))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("POST %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// If response is SSE (text/event-stream), extract the last data payload.
+	contentType := resp.Header.Get("Content-Type")
+	if strings.HasPrefix(contentType, "text/event-stream") {
+		body = extractSSEData(body)
+	}
+
+	return body, nil
+}
+
+// extractSSEData parses SSE-formatted response and returns
+// the last valid JSON data payload.
+func extractSSEData(body []byte) []byte {
+	lines := strings.Split(string(body), "\n")
+	var lastData []byte
+	var dataLines []string
+
+	for _, rawLine := range lines {
+		line := strings.TrimRight(rawLine, "\r")
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "" {
+			// End of event — flush accumulated data lines.
+			if len(dataLines) > 0 {
+				combined := strings.Join(dataLines, "\n")
+				if combined != "[DONE]" && json.Valid([]byte(combined)) {
+					lastData = []byte(combined)
+				}
+				dataLines = dataLines[:0]
+			}
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "data:") {
+			payload := strings.TrimSpace(strings.TrimPrefix(trimmed, "data:"))
+			dataLines = append(dataLines, payload)
+		}
+	}
+
+	// Handle unterminated last event.
+	if len(dataLines) > 0 {
+		combined := strings.Join(dataLines, "\n")
+		if combined != "[DONE]" && json.Valid([]byte(combined)) {
+			lastData = []byte(combined)
+		}
+	}
+
+	if lastData != nil {
+		return lastData
+	}
+	return body
+}
+
+// writeErrorResponse writes a JSON-RPC error response to the writer,
+// extracting the request ID from the original message if possible.
+func writeErrorResponse(w io.Writer, originalMsg string, proxyErr error) {
+	id := extractRequestID(originalMsg)
+	errResp := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    -32000,
+			"message": fmt.Sprintf("proxy: master unreachable: %v", proxyErr),
+		},
+	}
+	data, _ := json.Marshal(errResp)
+	fmt.Fprintf(w, "%s\n", data)
+}
+
+// extractRequestID attempts to extract the "id" field from a JSON-RPC message.
+func extractRequestID(msg string) any {
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(msg), &parsed); err != nil {
+		return nil
+	}
+	return parsed["id"]
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -112,6 +112,9 @@ func forwardToMaster(client *http.Client, url string, message []byte) ([]byte, e
 // only well-formed JSON is ever forwarded to the IDE.
 func extractSSEPayload(body []byte) json.RawMessage {
 	scanner := bufio.NewScanner(bytes.NewReader(body))
+	// Expand scanner buffer to 10MB to avoid dropping large JSON-RPC SSE payloads
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+
 	var lastValid json.RawMessage
 	var dataLines []string
 
@@ -138,6 +141,10 @@ func extractSSEPayload(body []byte) json.RawMessage {
 			payload := strings.TrimSpace(strings.TrimPrefix(trimmed, "data:"))
 			dataLines = append(dataLines, payload)
 		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		logger.Instance.Error("Proxy SSE extraction scan error: %v", err)
 	}
 
 	// Handle unterminated last event.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -74,9 +74,13 @@ func forwardToMaster(client *http.Client, url string, message []byte) ([]byte, e
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	const maxResponseBytes = 10 * 1024 * 1024 // 10MB — consistent with scanner buffer in RunProxyMode
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if int64(len(body)) > maxResponseBytes {
+		return nil, fmt.Errorf("response too large (>10MB) from master")
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -84,32 +84,50 @@ func forwardToMaster(client *http.Client, url string, message []byte) ([]byte, e
 		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
 	}
 
-	// If response is SSE (text/event-stream), extract the last data payload.
-	contentType := resp.Header.Get("Content-Type")
-	if strings.HasPrefix(contentType, "text/event-stream") {
-		body = extractSSEData(body)
+	// Validate response is well-formed JSON before forwarding to IDE.
+	// Strategy: try json.Unmarshal first (handles application/json).
+	// If it fails and Content-Type is SSE, extract JSON from data: lines.
+	var validated json.RawMessage
+	if json.Unmarshal(body, &validated) == nil {
+		// Body is already valid JSON — use it directly.
+		return validated, nil
 	}
 
-	return body, nil
+	// Not direct JSON — try SSE extraction if Content-Type matches.
+	contentType := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(contentType, "text/event-stream") {
+		return nil, fmt.Errorf("response is neither valid JSON nor SSE (content-type=%s, %d bytes)", contentType, len(body))
+	}
+
+	extracted := extractSSEPayload(body)
+	if extracted == nil {
+		return nil, fmt.Errorf("failed to extract valid JSON from SSE response (%d bytes)", len(body))
+	}
+	return extracted, nil
 }
 
-// extractSSEData parses SSE-formatted response and returns
-// the last valid JSON data payload.
-func extractSSEData(body []byte) []byte {
-	lines := strings.Split(string(body), "\n")
-	var lastData []byte
+// extractSSEPayload parses SSE-formatted response body and returns
+// the last valid JSON-RPC payload. Returns nil if no valid JSON is found.
+// All extracted data is validated through json.Unmarshal to ensure
+// only well-formed JSON is ever forwarded to the IDE.
+func extractSSEPayload(body []byte) json.RawMessage {
+	scanner := bufio.NewScanner(bytes.NewReader(body))
+	var lastValid json.RawMessage
 	var dataLines []string
 
-	for _, rawLine := range lines {
-		line := strings.TrimRight(rawLine, "\r")
+	for scanner.Scan() {
+		line := scanner.Text()
 		trimmed := strings.TrimSpace(line)
 
 		if trimmed == "" {
-			// End of event — flush accumulated data lines.
+			// End of SSE event — flush accumulated data lines.
 			if len(dataLines) > 0 {
 				combined := strings.Join(dataLines, "\n")
-				if combined != "[DONE]" && json.Valid([]byte(combined)) {
-					lastData = []byte(combined)
+				if combined != "[DONE]" {
+					var msg json.RawMessage
+					if json.Unmarshal([]byte(combined), &msg) == nil {
+						lastValid = msg
+					}
 				}
 				dataLines = dataLines[:0]
 			}
@@ -125,15 +143,15 @@ func extractSSEData(body []byte) []byte {
 	// Handle unterminated last event.
 	if len(dataLines) > 0 {
 		combined := strings.Join(dataLines, "\n")
-		if combined != "[DONE]" && json.Valid([]byte(combined)) {
-			lastData = []byte(combined)
+		if combined != "[DONE]" {
+			var msg json.RawMessage
+			if json.Unmarshal([]byte(combined), &msg) == nil {
+				lastValid = msg
+			}
 		}
 	}
 
-	if lastData != nil {
-		return lastData
-	}
-	return body
+	return lastValid
 }
 
 // writeErrorResponse writes a JSON-RPC error response to the writer,

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -19,9 +19,8 @@ import (
 // as HTTP POST requests to the master instance on the given port,
 // and writes the responses back to stdout.
 //
-// This function blocks until stdin is closed (EOF) or the context is cancelled.
-// It never returns under normal operation — the process exits when the IDE
-// closes the stdin pipe.
+// This function blocks while stdin is open and readable, and returns when
+// stdin is closed (EOF) or a read error occurs (e.g. scanner error).
 func RunProxyMode(port int) {
 	logger.Instance.Info("Entering PROXY mode → forwarding Stdio to http://127.0.0.1:%d/mcp", port)
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -217,8 +219,15 @@ func TestWriteErrorResponse_InvalidJSON_NilID(t *testing.T) {
 // ── PortIsOccupied tests ─────────────────────────────────────────────
 
 func TestPortIsOccupied_FreePort(t *testing.T) {
-	if PortIsOccupied(59999) {
-		t.Error("expected port 59999 to be free")
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+	
+	if PortIsOccupied(port) {
+		t.Errorf("expected ephemeral port %d to be free", port)
 	}
 }
 
@@ -228,8 +237,14 @@ func TestPortIsOccupied_OccupiedPort(t *testing.T) {
 	defer server.Close()
 
 	// Extract port from server URL (e.g. "http://127.0.0.1:12345")
-	parts := strings.Split(server.URL, ":")
-	portStr := parts[len(parts)-1]
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse url: %v", err)
+	}
+	_, portStr, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatalf("failed to split host/port: %v", err)
+	}
 	var port int
 	_, _ = fmt.Sscanf(portStr, "%d", &port)
 
@@ -268,8 +283,14 @@ func TestQueryMasterVersion_ValidResponse(t *testing.T) {
 	}))
 	defer server.Close()
 
-	parts := strings.Split(server.URL, ":")
-	portStr := parts[len(parts)-1]
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse url: %v", err)
+	}
+	_, portStr, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatalf("failed to split host/port: %v", err)
+	}
 	var port int
 	_, _ = fmt.Sscanf(portStr, "%d", &port)
 
@@ -280,7 +301,14 @@ func TestQueryMasterVersion_ValidResponse(t *testing.T) {
 }
 
 func TestQueryMasterVersion_Unreachable(t *testing.T) {
-	version := QueryMasterVersion(59998)
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+	
+	version := QueryMasterVersion(port)
 	if version != "" {
 		t.Errorf("expected empty version for unreachable port, got %q", version)
 	}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1,0 +1,287 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ── extractSSEPayload tests ──────────────────────────────────────────
+
+func TestExtractSSEPayload_SingleEvent(t *testing.T) {
+	body := []byte("data: {\"jsonrpc\":\"2.0\",\"id\":\"1\",\"result\":{\"tools\":[]}}\n\n")
+	result := extractSSEPayload(body)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	if parsed["jsonrpc"] != "2.0" {
+		t.Errorf("expected jsonrpc=2.0, got %v", parsed["jsonrpc"])
+	}
+}
+
+func TestExtractSSEPayload_MultipleEvents_ReturnsLast(t *testing.T) {
+	body := []byte(
+		"data: {\"jsonrpc\":\"2.0\",\"id\":\"1\",\"result\":{\"first\":true}}\n\n" +
+			"data: {\"jsonrpc\":\"2.0\",\"id\":\"1\",\"result\":{\"last\":true}}\n\n",
+	)
+	result := extractSSEPayload(body)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	res := parsed["result"].(map[string]any)
+	if res["last"] != true {
+		t.Errorf("expected last event, got %v", res)
+	}
+}
+
+func TestExtractSSEPayload_DoneEvent_Ignored(t *testing.T) {
+	body := []byte(
+		"data: {\"jsonrpc\":\"2.0\",\"id\":\"1\",\"result\":{}}\n\n" +
+			"data: [DONE]\n\n",
+	)
+	result := extractSSEPayload(body)
+	if result == nil {
+		t.Fatal("expected non-nil result (should skip [DONE])")
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+}
+
+func TestExtractSSEPayload_InvalidJSON_ReturnsNil(t *testing.T) {
+	body := []byte("data: this is not json\n\n")
+	result := extractSSEPayload(body)
+	if result != nil {
+		t.Errorf("expected nil for invalid JSON, got %s", result)
+	}
+}
+
+func TestExtractSSEPayload_EmptyBody_ReturnsNil(t *testing.T) {
+	result := extractSSEPayload([]byte{})
+	if result != nil {
+		t.Errorf("expected nil for empty body, got %s", result)
+	}
+}
+
+func TestExtractSSEPayload_UnterminatedEvent(t *testing.T) {
+	// No trailing blank line — should still extract.
+	body := []byte("data: {\"jsonrpc\":\"2.0\",\"id\":\"1\",\"result\":{}}")
+	result := extractSSEPayload(body)
+	if result == nil {
+		t.Fatal("expected non-nil result for unterminated event")
+	}
+}
+
+// ── forwardToMaster tests ────────────────────────────────────────────
+
+func TestForwardToMaster_JSONResponse(t *testing.T) {
+	expected := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "42",
+		"result":  map[string]any{"status": "ok"},
+	}
+	expectedBytes, _ := json.Marshal(expected)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(expectedBytes)
+	}))
+	defer server.Close()
+
+	client := &http.Client{}
+	msg := []byte(`{"jsonrpc":"2.0","id":"42","method":"tools/list","params":{}}`)
+	result, err := forwardToMaster(client, server.URL, msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	if parsed["id"] != "42" {
+		t.Errorf("expected id=42, got %v", parsed["id"])
+	}
+}
+
+func TestForwardToMaster_SSEResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: {\"jsonrpc\":\"2.0\",\"id\":\"1\",\"result\":{\"tools\":[]}}\n\n")
+	}))
+	defer server.Close()
+
+	client := &http.Client{}
+	msg := []byte(`{"jsonrpc":"2.0","id":"1","method":"tools/list","params":{}}`)
+	result, err := forwardToMaster(client, server.URL, msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+}
+
+func TestForwardToMaster_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer server.Close()
+
+	client := &http.Client{}
+	msg := []byte(`{"jsonrpc":"2.0","id":"1","method":"tools/list","params":{}}`)
+	_, err := forwardToMaster(client, server.URL, msg)
+	if err == nil {
+		t.Fatal("expected error for 500 status")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("expected error to mention status 500, got: %v", err)
+	}
+}
+
+func TestForwardToMaster_InvalidContentType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write([]byte("this is not json or sse"))
+	}))
+	defer server.Close()
+
+	client := &http.Client{}
+	msg := []byte(`{"jsonrpc":"2.0","id":"1","method":"tools/list","params":{}}`)
+	_, err := forwardToMaster(client, server.URL, msg)
+	if err == nil {
+		t.Fatal("expected error for non-JSON non-SSE response")
+	}
+	if !strings.Contains(err.Error(), "neither valid JSON nor SSE") {
+		t.Errorf("expected descriptive error, got: %v", err)
+	}
+}
+
+// ── writeErrorResponse tests ─────────────────────────────────────────
+
+func TestWriteErrorResponse(t *testing.T) {
+	var buf bytes.Buffer
+	writeErrorResponse(&buf, `{"jsonrpc":"2.0","id":"test-123","method":"tools/call"}`, fmt.Errorf("connection refused"))
+
+	var parsed map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("error response is not valid JSON: %v\nbody: %s", err, buf.String())
+	}
+
+	if parsed["id"] != "test-123" {
+		t.Errorf("expected id=test-123, got %v", parsed["id"])
+	}
+	if parsed["jsonrpc"] != "2.0" {
+		t.Errorf("expected jsonrpc=2.0, got %v", parsed["jsonrpc"])
+	}
+	errObj := parsed["error"].(map[string]any)
+	msg := errObj["message"].(string)
+	if !strings.Contains(msg, "connection refused") {
+		t.Errorf("expected error message to contain original error, got: %s", msg)
+	}
+}
+
+func TestWriteErrorResponse_InvalidJSON_NilID(t *testing.T) {
+	var buf bytes.Buffer
+	writeErrorResponse(&buf, "this is not json", fmt.Errorf("timeout"))
+
+	var parsed map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("error response is not valid JSON: %v", err)
+	}
+	if parsed["id"] != nil {
+		t.Errorf("expected nil id for unparseable request, got %v", parsed["id"])
+	}
+}
+
+// ── PortIsOccupied tests ─────────────────────────────────────────────
+
+func TestPortIsOccupied_FreePort(t *testing.T) {
+	if PortIsOccupied(59999) {
+		t.Error("expected port 59999 to be free")
+	}
+}
+
+func TestPortIsOccupied_OccupiedPort(t *testing.T) {
+	// Start a test server to occupy a port.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer server.Close()
+
+	// Extract port from server URL (e.g. "http://127.0.0.1:12345")
+	parts := strings.Split(server.URL, ":")
+	portStr := parts[len(parts)-1]
+	var port int
+	fmt.Sscanf(portStr, "%d", &port)
+
+	if !PortIsOccupied(port) {
+		t.Errorf("expected port %d to be occupied", port)
+	}
+}
+
+// ── QueryMasterVersion tests ─────────────────────────────────────────
+
+func TestQueryMasterVersion_ValidResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Read and validate the incoming request is an initialize call.
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		json.Unmarshal(body, &req)
+
+		if req["method"] != "initialize" {
+			t.Errorf("expected initialize method, got %v", req["method"])
+		}
+
+		resp := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      req["id"],
+			"result": map[string]any{
+				"serverInfo": map[string]any{
+					"name":    "ragcode",
+					"version": "2.1.51",
+				},
+				"protocolVersion": "2025-03-26",
+				"capabilities":    map[string]any{},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	parts := strings.Split(server.URL, ":")
+	portStr := parts[len(parts)-1]
+	var port int
+	fmt.Sscanf(portStr, "%d", &port)
+
+	version := QueryMasterVersion(port)
+	if version != "2.1.51" {
+		t.Errorf("expected version 2.1.51, got %q", version)
+	}
+}
+
+func TestQueryMasterVersion_Unreachable(t *testing.T) {
+	version := QueryMasterVersion(59998)
+	if version != "" {
+		t.Errorf("expected empty version for unreachable port, got %q", version)
+	}
+}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -101,7 +101,7 @@ func TestForwardToMaster_JSONResponse(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(expectedBytes)
+		_, _ = w.Write(expectedBytes)
 	}))
 	defer server.Close()
 
@@ -144,7 +144,7 @@ func TestForwardToMaster_SSEResponse(t *testing.T) {
 func TestForwardToMaster_ServerError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("internal error"))
+		_, _ = w.Write([]byte("internal error"))
 	}))
 	defer server.Close()
 
@@ -162,7 +162,7 @@ func TestForwardToMaster_ServerError(t *testing.T) {
 func TestForwardToMaster_InvalidContentType(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
-		w.Write([]byte("this is not json or sse"))
+		_, _ = w.Write([]byte("this is not json or sse"))
 	}))
 	defer server.Close()
 
@@ -231,7 +231,7 @@ func TestPortIsOccupied_OccupiedPort(t *testing.T) {
 	parts := strings.Split(server.URL, ":")
 	portStr := parts[len(parts)-1]
 	var port int
-	fmt.Sscanf(portStr, "%d", &port)
+	_, _ = fmt.Sscanf(portStr, "%d", &port)
 
 	if !PortIsOccupied(port) {
 		t.Errorf("expected port %d to be occupied", port)
@@ -245,7 +245,7 @@ func TestQueryMasterVersion_ValidResponse(t *testing.T) {
 		// Read and validate the incoming request is an initialize call.
 		body, _ := io.ReadAll(r.Body)
 		var req map[string]any
-		json.Unmarshal(body, &req)
+		_ = json.Unmarshal(body, &req)
 
 		if req["method"] != "initialize" {
 			t.Errorf("expected initialize method, got %v", req["method"])
@@ -264,14 +264,14 @@ func TestQueryMasterVersion_ValidResponse(t *testing.T) {
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
 	parts := strings.Split(server.URL, ":")
 	portStr := parts[len(parts)-1]
 	var port int
-	fmt.Sscanf(portStr, "%d", &port)
+	_, _ = fmt.Sscanf(portStr, "%d", &port)
 
 	version := QueryMasterVersion(port)
 	if version != "2.1.51" {

--- a/internal/service/engine/engine.go
+++ b/internal/service/engine/engine.go
@@ -309,7 +309,7 @@ func (e *Engine) SearchCode(ctx context.Context, filePath, queryText string, lim
 				log.Printf("[INFO] Detectată indexare întreruptă (rămasă la %d%%). Se reia automat...", idxState.LastPercent)
 				e.StartIndexingAsync(wctx.Root, wctx.ID, nil, false)
 			}
-			// In ambele cazuri continuăm — Qdrant are deja date parțiale, progresul e inclus în response
+			// În ambele cazuri continuăm — Qdrant are deja date parțiale, iar progresul este adăugat în răspuns la nivelul MCP tool-ului
 			log.Printf("[INFO] Indexing in progress (%d%%) — searching available results in Qdrant", idxState.LastPercent)
 		}
 	}
@@ -465,7 +465,7 @@ func (e *Engine) HybridSearchCode(ctx context.Context, filePath, queryText strin
 				log.Printf("[INFO] Detectată indexare întreruptă (rămasă la %d%%). Se reia automat...", idxState.LastPercent)
 				e.StartIndexingAsync(wctx.Root, wctx.ID, nil, false)
 			}
-			// În ambele cazuri continuăm — Qdrant are deja date parțiale, progresul e inclus în response
+			// În ambele cazuri continuăm — Qdrant are deja date parțiale, iar progresul este adăugat în răspuns la nivelul MCP tool-ului
 			log.Printf("[INFO] Indexing in progress (%d%%) — searching available results in Qdrant", idxState.LastPercent)
 		}
 	}

--- a/internal/service/engine/engine.go
+++ b/internal/service/engine/engine.go
@@ -305,10 +305,12 @@ func (e *Engine) SearchCode(ctx context.Context, filePath, queryText string, lim
 	if idxState, sErr := indexer.LoadState(indexerStatePath); sErr == nil {
 		if idxState.LastPercent > 0 && idxState.LastPercent < 100 {
 			if _, ok := e.indexingJobs.Load(wctx.ID); !ok {
+				// Indexare întreruptă (crash/restart) — repornim în background dar continuăm search-ul
 				log.Printf("[INFO] Detectată indexare întreruptă (rămasă la %d%%). Se reia automat...", idxState.LastPercent)
 				e.StartIndexingAsync(wctx.Root, wctx.ID, nil, false)
 			}
-			return nil, &ErrIndexingInProgress{WorkspaceRoot: wctx.Root, WorkspaceID: wctx.ID, LastPercent: idxState.LastPercent}
+			// In ambele cazuri continuăm — Qdrant are deja date parțiale, progresul e inclus în response
+			log.Printf("[INFO] Indexing in progress (%d%%) — searching available results in Qdrant", idxState.LastPercent)
 		}
 	}
 
@@ -459,10 +461,12 @@ func (e *Engine) HybridSearchCode(ctx context.Context, filePath, queryText strin
 	if idxState, sErr := indexer.LoadState(indexerStatePath); sErr == nil {
 		if idxState.LastPercent > 0 && idxState.LastPercent < 100 {
 			if _, ok := e.indexingJobs.Load(wctx.ID); !ok {
+				// Indexare întreruptă (crash/restart) — repornim în background dar continuăm search-ul
 				log.Printf("[INFO] Detectată indexare întreruptă (rămasă la %d%%). Se reia automat...", idxState.LastPercent)
 				e.StartIndexingAsync(wctx.Root, wctx.ID, nil, false)
 			}
-			return nil, &ErrIndexingInProgress{WorkspaceRoot: wctx.Root, WorkspaceID: wctx.ID, LastPercent: idxState.LastPercent}
+			// În ambele cazuri continuăm — Qdrant are deja date parțiale, progresul e inclus în response
+			log.Printf("[INFO] Indexing in progress (%d%%) — searching available results in Qdrant", idxState.LastPercent)
 		}
 	}
 

--- a/internal/service/engine/engine.go
+++ b/internal/service/engine/engine.go
@@ -48,6 +48,11 @@ type Engine struct {
 	// detectionCache stores resolved WorkspaceContext with TTL to avoid
 	// repeated full resolver cascades for the same path.
 	detectionCache sync.Map // map[string]*detectionCacheEntry
+
+	// resumeAttempts throttles auto-resume of interrupted indexing.
+	// Key: workspace ID, Value: time.Time of last resume attempt.
+	// Prevents CPU/log churn when indexing keeps failing (e.g. Ollama down).
+	resumeAttempts sync.Map
 }
 
 // detectionCacheEntry wraps a cached WorkspaceContext with an expiry.
@@ -305,9 +310,15 @@ func (e *Engine) SearchCode(ctx context.Context, filePath, queryText string, lim
 	if idxState, sErr := indexer.LoadState(indexerStatePath); sErr == nil {
 		if idxState.LastPercent > 0 && idxState.LastPercent < 100 {
 			if _, ok := e.indexingJobs.Load(wctx.ID); !ok {
-				// Indexare întreruptă (crash/restart) — repornim în background dar continuăm search-ul
-				log.Printf("[INFO] Detectată indexare întreruptă (rămasă la %d%%). Se reia automat...", idxState.LastPercent)
-				e.StartIndexingAsync(wctx.Root, wctx.ID, nil, false)
+				// Throttle auto-resume: only once per 5 minutes per workspace to avoid
+				// CPU/log churn when indexing keeps failing (e.g. Ollama is down).
+				const resumeCooldown = 5 * time.Minute
+				now := time.Now()
+				if last, loaded := e.resumeAttempts.Load(wctx.ID); !loaded || now.Sub(last.(time.Time)) > resumeCooldown {
+					e.resumeAttempts.Store(wctx.ID, now)
+					log.Printf("[INFO] Detectată indexare întreruptă (rămasă la %d%%). Se reia automat...", idxState.LastPercent)
+					e.StartIndexingAsync(wctx.Root, wctx.ID, nil, false)
+				}
 			}
 			// În ambele cazuri continuăm — Qdrant are deja date parțiale, iar progresul este adăugat în răspuns la nivelul MCP tool-ului
 			log.Printf("[INFO] Indexing in progress (%d%%) — searching available results in Qdrant", idxState.LastPercent)
@@ -461,9 +472,15 @@ func (e *Engine) HybridSearchCode(ctx context.Context, filePath, queryText strin
 	if idxState, sErr := indexer.LoadState(indexerStatePath); sErr == nil {
 		if idxState.LastPercent > 0 && idxState.LastPercent < 100 {
 			if _, ok := e.indexingJobs.Load(wctx.ID); !ok {
-				// Indexare întreruptă (crash/restart) — repornim în background dar continuăm search-ul
-				log.Printf("[INFO] Detectată indexare întreruptă (rămasă la %d%%). Se reia automat...", idxState.LastPercent)
-				e.StartIndexingAsync(wctx.Root, wctx.ID, nil, false)
+				// Throttle auto-resume: only once per 5 minutes per workspace to avoid
+				// CPU/log churn when indexing keeps failing (e.g. Ollama is down).
+				const resumeCooldown = 5 * time.Minute
+				now := time.Now()
+				if last, loaded := e.resumeAttempts.Load(wctx.ID); !loaded || now.Sub(last.(time.Time)) > resumeCooldown {
+					e.resumeAttempts.Store(wctx.ID, now)
+					log.Printf("[INFO] Detectată indexare întreruptă (rămasă la %d%%). Se reia automat...", idxState.LastPercent)
+					e.StartIndexingAsync(wctx.Root, wctx.ID, nil, false)
+				}
 			}
 			// În ambele cazuri continuăm — Qdrant are deja date parțiale, iar progresul este adăugat în răspuns la nivelul MCP tool-ului
 			log.Printf("[INFO] Indexing in progress (%d%%) — searching available results in Qdrant", idxState.LastPercent)

--- a/internal/service/engine/engine_searchcode_test.go
+++ b/internal/service/engine/engine_searchcode_test.go
@@ -310,14 +310,14 @@ func TestSearchCodeResumeInterruptedIndexing(t *testing.T) {
 	}
 
 	// Așteptăm ca job-ul din background să se termine și să iasă din indexingJobs.
-	// (Previne eroarea de t.TempDir() "directory not empty").
+	// (Previne eroarea de t.TempDir() "directory not empty"). Limităm la max 5 secunde.
 	for i := 0; i < 100; i++ {
 		if _, ok := eng.indexingJobs.Load(wctx.ID); !ok {
 			return // Success: job started and cleanly finished
 		}
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 	}
-	t.Errorf("Expected background indexing to finish, but job is still active")
+	t.Errorf("Expected background indexing to finish within 5s, but job is still active")
 }
 
 // mockDirDetector is like mockDetector but allows specifying the root dir

--- a/internal/service/engine/engine_searchcode_test.go
+++ b/internal/service/engine/engine_searchcode_test.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"context"
 	"path/filepath"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -281,6 +280,20 @@ func TestSearchCodeResumeInterruptedIndexing(t *testing.T) {
 	rootDir := t.TempDir()
 	eng.SetResolver(resolver.New(resolver.Dependencies{Detector: &mockDirDetector{root: rootDir}}))
 
+	// Get workspace ID early
+	wctx, _ := eng.DetectContext(context.Background(), "dummy.go")
+	if wctx == nil {
+		t.Fatalf("Failed to detect context")
+	}
+	// Make the collection exist so search continues
+	goColl := CollectionNameFor(wctx.ID, "go")
+	store := &multiLangStore{
+		testStore: testStore{
+			existing: map[string]bool{goColl: true},
+		},
+	}
+	eng.SetSearchService(search.NewService(llmProvider, store))
+
 	// Creăm state.json cu LastPercent = 55%
 	state := indexer.NewState()
 	state.SetLastPercent(55)
@@ -289,28 +302,22 @@ func TestSearchCodeResumeInterruptedIndexing(t *testing.T) {
 		t.Fatalf("Failed to save fake state.json: %v", err)
 	}
 
-	// Colecția nu există, iar LastPercent e 55, ar trebui să dea eroare specifică "resuming from 55%"
+	// Cu noua logică: search-ul NU mai blochează când LastPercent e între 1-99.
+	// Indexarea întreruptă e reluată automat în background, iar search-ul continuă în Qdrant.
 	_, err := eng.SearchCode(context.Background(), "dummy.go", "test", 10, false)
-	if err == nil {
-		t.Fatalf("Expected ErrIndexingInProgress, got nil")
+	if err != nil {
+		t.Fatalf("Expected no error, search should continue, got: %v", err)
 	}
 
-	errStr := err.Error()
-	expectedSubstr := "resuming from 55%"
-	if !strings.Contains(errStr, expectedSubstr) {
-		t.Errorf("Expected error to contain %q, but got %q", expectedSubstr, errStr)
-	}
-
-	// Determine the resolved workspace ID to wait for background indexer
-	wctx, _ := eng.DetectContext(context.Background(), "dummy.go")
-	if wctx != nil {
-		for i := 0; i < 50; i++ {
-			if _, ok := eng.indexingJobs.Load(wctx.ID); !ok {
-				break
-			}
-			time.Sleep(10 * time.Millisecond)
+	// Verificăm că indexarea a fost repornită în background
+	for i := 0; i < 50; i++ {
+		if _, ok := eng.indexingJobs.Load(wctx.ID); ok {
+			return // Success
+			time.Sleep(20 * time.Millisecond)
 		}
+		time.Sleep(10 * time.Millisecond)
 	}
+	t.Errorf("Expected background indexing to be resumed, but no active job found")
 }
 
 // mockDirDetector is like mockDetector but allows specifying the root dir

--- a/internal/service/engine/engine_searchcode_test.go
+++ b/internal/service/engine/engine_searchcode_test.go
@@ -309,15 +309,15 @@ func TestSearchCodeResumeInterruptedIndexing(t *testing.T) {
 		t.Fatalf("Expected no error, search should continue, got: %v", err)
 	}
 
-	// Verificăm că indexarea a fost repornită în background
-	for i := 0; i < 50; i++ {
-		if _, ok := eng.indexingJobs.Load(wctx.ID); ok {
-			return // Success
-			time.Sleep(20 * time.Millisecond)
+	// Așteptăm ca job-ul din background să se termine și să iasă din indexingJobs.
+	// (Previne eroarea de t.TempDir() "directory not empty").
+	for i := 0; i < 100; i++ {
+		if _, ok := eng.indexingJobs.Load(wctx.ID); !ok {
+			return // Success: job started and cleanly finished
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Errorf("Expected background indexing to be resumed, but no active job found")
+	t.Errorf("Expected background indexing to finish, but job is still active")
 }
 
 // mockDirDetector is like mockDetector but allows specifying the root dir

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -10,8 +10,13 @@ nv="$maj.$min.$pat"
 perl -0777 -i -pe 's/(\bVersion\s*=\s*")([^"]+)(")/${1}'"$nv"'${3}/' "$MAIN_GO"
 mkdir -p "$BIN_DIR"
 # Kill running instances before overwriting binaries (dev convenience).
-pkill -f rag-code-mcp || true
-sleep 0.5
+# Uses exact name match (-x) to avoid killing unrelated processes that happen
+# to have "rag-code-mcp" somewhere in their command line.
+# Set RAGCODE_KILL_PROCS=0 to skip this step.
+if [[ "${RAGCODE_KILL_PROCS:-1}" == "1" ]]; then
+  pkill -x rag-code-mcp || true
+  sleep 0.5
+fi
 go build -o "$BIN_DIR/rag-code-mcp" "$ROOT_DIR/cmd/rag-code-mcp"
 go build -o "$BIN_DIR/rag-code-install" "$ROOT_DIR/cmd/rag-code-install"
 cp "$ROOT_DIR/internal/config/default.yaml" "$BIN_DIR/config.yaml"

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -9,6 +9,9 @@ maj="${BASH_REMATCH[1]}"; min="${BASH_REMATCH[2]}"; pat=$((BASH_REMATCH[3]+1))
 nv="$maj.$min.$pat"
 perl -0777 -i -pe 's/(\bVersion\s*=\s*")([^"]+)(")/${1}'"$nv"'${3}/' "$MAIN_GO"
 mkdir -p "$BIN_DIR"
+# Kill running instances before overwriting binaries (dev convenience).
+pkill -f rag-code-mcp || true
+sleep 0.5
 go build -o "$BIN_DIR/rag-code-mcp" "$ROOT_DIR/cmd/rag-code-mcp"
 go build -o "$BIN_DIR/rag-code-install" "$ROOT_DIR/cmd/rag-code-install"
 cp "$ROOT_DIR/internal/config/default.yaml" "$BIN_DIR/config.yaml"


### PR DESCRIPTION
## Description
This Pull Request introduces the **Single Instance Proxy Architecture** and fixes a critical bug in the search engine regarding blocked queries during active indexing.
**Key changes:**
1. **Proxy Mode Architecture:**
   - Implemented a master-proxy architecture to ensure only a single instance of `rag-code-mcp` handles heavy processing (like Ollama/Qdrant interactions).
   - When multiple IDEs connect, subsequent instances detect the master process and act as lightweight Stdio-to-HTTP proxies, forwarding JSON-RPC messages to the master.
2. **Engine Search Fix (Non-blocking during indexing):**
   - Fixed an issue where [ErrIndexingInProgress](cci:2://file:///home/razvan/go/src/github.com/doITmagic/rag-code-mcp/internal/service/engine/engine.go:258:0-262:1) completely blocked search queries while background indexing was active (preventing access even to already-indexed files).
   - Search queries now correctly proceed to Qdrant to retrieve files that have already been embedded, even during active full/incremental indexing.
   - Refined the "resume interrupted indexing" (crash recovery) mechanism to silently restart indexing in the background without blocking the immediate search request.
3. **Test Stability:**
   - Fixed a `TempDir` race condition in Go 1.24 tests by ensuring background indexing jobs exit cleanly before the test finishes.
Fixes # (issue) <!-- Adaugă numărul issue-ului aici dacă există, altfel poți șterge linia -->
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have formatted my code with `go fmt ./...`
- [x] I have run tests `go test ./...` and they pass
- [x] I have verified integration with Ollama/Qdrant (if applicable)
- [x] I have updated the documentation accordingly