### PR TITLE
feat: use X-Workspace-Hint as workspace detection fallback (#30)

### DIFF
--- a/cmd/rag-code-mcp/main.go
+++ b/cmd/rag-code-mcp/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	Version = "2.1.53"
+	Version = "2.1.56"
 	Commit  = "none"
 	Date    = "24.10.2025"
 )

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -16,7 +16,9 @@ import (
 // RunBridge reads JSON-RPC messages from stdin, forwards each as an HTTP POST
 // to the daemon via Unix socket, and writes the JSON response to stdout.
 //
-// This is the core of the stdio adapter — zero SSE, pure JSON request/response.
+// The adapter reads/writes single JSON payloads (no SSE framing).
+// Accept header includes text/event-stream for StreamableHTTPHandler compatibility,
+// but JSONResponse=true on the server forces pure JSON responses.
 // Returns nil on stdin EOF (normal IDE shutdown).
 func RunBridge(ctx context.Context, socketPath string, stdin io.Reader, stdout io.Writer, workspaceHint string) error {
 	client := &http.Client{

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -45,7 +45,7 @@ func RunBridge(ctx context.Context, socketPath string, stdin io.Reader, stdout i
 			continue
 		}
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Accept", "application/json")
+		req.Header.Set("Accept", "application/json, text/event-stream")
 		if workspaceHint != "" {
 			req.Header.Set("X-Workspace-Hint", workspaceHint)
 		}

--- a/internal/daemon/run.go
+++ b/internal/daemon/run.go
@@ -161,7 +161,8 @@ func Run(rcfg RunConfig) error {
 	streamableHandler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
 		return mcpServer
 	}, &mcp.StreamableHTTPOptions{
-		Stateless: true,
+		Stateless:    true,
+		JSONResponse: true,
 	})
 
 	mcpMux := http.NewServeMux()

--- a/internal/daemon/run.go
+++ b/internal/daemon/run.go
@@ -15,6 +15,7 @@ import (
 	"github.com/doITmagic/rag-code-mcp/internal/service/engine"
 	"github.com/doITmagic/rag-code-mcp/internal/service/search"
 	"github.com/doITmagic/rag-code-mcp/internal/service/tools"
+	"github.com/doITmagic/rag-code-mcp/internal/transport"
 	"github.com/doITmagic/rag-code-mcp/internal/utils"
 	"github.com/doITmagic/rag-code-mcp/pkg/indexer"
 	"github.com/doITmagic/rag-code-mcp/pkg/llm"
@@ -168,6 +169,15 @@ func Run(rcfg RunConfig) error {
 	mcpMux := http.NewServeMux()
 	mcpMux.Handle("/mcp", streamableHandler)
 
+	// Middleware: extract X-Workspace-Hint header from adapter and inject into request context.
+	// This makes the IDE's CWD available to all tools via transport.GetWorkspaceHint(ctx).
+	mcpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if hint := r.Header.Get("X-Workspace-Hint"); hint != "" {
+			r = r.WithContext(transport.WithWorkspaceHint(r.Context(), hint))
+		}
+		mcpMux.ServeHTTP(w, r)
+	})
+
 	// ── Paths ──
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -188,7 +198,7 @@ func Run(rcfg RunConfig) error {
 		PIDPath:    pidPath,
 		Version:    rcfg.Version,
 		HTTPPort:   rcfg.HTTPPort,
-		Handler:    mcpMux,
+		Handler:    mcpHandler,
 		OnReady: func() {
 			logger.Instance.Info("Daemon ready — socket=%s, http_port=%d", socketPath, rcfg.HTTPPort)
 		},

--- a/internal/service/engine/engine.go
+++ b/internal/service/engine/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -184,11 +185,16 @@ func (e *Engine) DetectContext(ctx context.Context, path string) (*WorkspaceCont
 
 	if strings.TrimSpace(path) == "" {
 		// Tier 2: Try workspace hint from adapter (IDE's CWD injected via X-Workspace-Hint header)
-		if hint := transport.GetWorkspaceHint(ctx); hint != "" {
+		if hint := strings.TrimSpace(transport.GetWorkspaceHint(ctx)); hint != "" {
 			abs, err := filepath.Abs(hint)
 			if err == nil {
-				req.FilePath = abs
-				source = "hint_fallback"
+				// Validate the path actually exists on disk before using it
+				if _, statErr := os.Stat(abs); statErr == nil {
+					req.FilePath = abs
+					source = "hint_fallback"
+					// Use hint as cache key so different IDEs don't share the same empty-string entry
+					cacheKey = abs
+				}
 			}
 		}
 

--- a/internal/service/engine/engine.go
+++ b/internal/service/engine/engine.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/doITmagic/rag-code-mcp/internal/config"
 	"github.com/doITmagic/rag-code-mcp/internal/service/search"
+	"github.com/doITmagic/rag-code-mcp/internal/transport"
 	"github.com/doITmagic/rag-code-mcp/internal/skills"
 	"github.com/doITmagic/rag-code-mcp/pkg/indexer"
 	"github.com/doITmagic/rag-code-mcp/pkg/parser"
@@ -182,12 +183,24 @@ func (e *Engine) DetectContext(ctx context.Context, path string) (*WorkspaceCont
 	source := "explicit_file_path"
 
 	if strings.TrimSpace(path) == "" {
-		active, err := e.GetActiveWorkspace()
-		if err != nil || active == "" {
-			return nil, fmt.Errorf("❌ No workspace detected. Please provide the 'file_path' of the file you are currently working on to help detect the project context.")
+		// Tier 2: Try workspace hint from adapter (IDE's CWD injected via X-Workspace-Hint header)
+		if hint := transport.GetWorkspaceHint(ctx); hint != "" {
+			abs, err := filepath.Abs(hint)
+			if err == nil {
+				req.FilePath = abs
+				source = "hint_fallback"
+			}
 		}
-		req.WorkspaceRoot = active
-		source = "registry_fallback"
+
+		// Tier 3: Fall back to last active workspace from registry
+		if req.FilePath == "" {
+			active, err := e.GetActiveWorkspace()
+			if err != nil || active == "" {
+				return nil, fmt.Errorf("❌ No workspace detected. Please provide the 'file_path' of the file you are currently working on to help detect the project context.")
+			}
+			req.WorkspaceRoot = active
+			source = "registry_fallback"
+		}
 	} else {
 		abs, err := filepath.Abs(path)
 		if err != nil {

--- a/internal/transport/context.go
+++ b/internal/transport/context.go
@@ -1,0 +1,26 @@
+// Package transport provides shared context keys and helpers for the
+// daemon ↔ adapter transport layer. It has zero internal dependencies,
+// so both daemon and engine can import it without cycles.
+package transport
+
+import "context"
+
+// contextKey is an unexported type to prevent collisions with keys from other packages.
+type contextKey string
+
+// workspaceHintKey is the context key for the X-Workspace-Hint header value.
+const workspaceHintKey contextKey = "workspace_hint"
+
+// WithWorkspaceHint returns a new context carrying the workspace hint (IDE's CWD).
+func WithWorkspaceHint(ctx context.Context, hint string) context.Context {
+	return context.WithValue(ctx, workspaceHintKey, hint)
+}
+
+// GetWorkspaceHint extracts the workspace hint from the context.
+// Returns empty string if not present.
+func GetWorkspaceHint(ctx context.Context) string {
+	if hint, ok := ctx.Value(workspaceHintKey).(string); ok {
+		return hint
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

Implements the daemon-side plumbing for using `X-Workspace-Hint` (IDE's CWD) as a workspace detection fallback when `file_path` is not provided by the AI agent.

Closes #30

## Changes

### New: `internal/transport/context.go`
- Shared context key + helpers (`WithWorkspaceHint`, `GetWorkspaceHint`)
- Zero internal dependencies — avoids import cycle between `daemon` ↔ `engine`

### Modified: `internal/daemon/run.go`
- Added HTTP middleware that extracts `X-Workspace-Hint` header from adapter requests and injects it into `context.Context`
- Uses `transport.WithWorkspaceHint()` so all downstream handlers/tools can access it

### Modified: `internal/service/engine/engine.go`
- `DetectContext()` now has a **3-tier fallback** when `file_path` is empty:
  1. **Tier 1**: Explicit `file_path` from agent (highest priority)
  2. **Tier 2**: `X-Workspace-Hint` from adapter/IDE CWD (NEW)
  3. **Tier 3**: Last active workspace from registry (existing behavior)
- New detection source: `"hint_fallback"` for traceability

### Also included (bug fixes from previous work):
- `main.go`: Version bump 2.1.53 → 2.1.56
- `adapter.go`: Accept header includes `text/event-stream` for StreamableHTTPHandler compatibility
- `run.go`: `JSONResponse=true` forces pure JSON responses (no SSE framing)

## How it works

```
IDE starts adapter → adapter captures os.Getwd() → sends X-Workspace-Hint header with every request
                                                          ↓
Daemon middleware extracts header → injects into context.Context
                                                          ↓
Tool calls engine.DetectContext(ctx, "") → checks context for hint → resolves workspace
```

## Test results

```
ok  github.com/doITmagic/rag-code-mcp/internal/daemon    0.065s
ok  github.com/doITmagic/rag-code-mcp/internal/service/engine  0.059s
```