### PR TITLE
fix(indexer): accurate global progress tracking + simplified goroutine model

### DIFF
--- a/docs/plans/2026-03-07-daemon-architecture-design.md
+++ b/docs/plans/2026-03-07-daemon-architecture-design.md
@@ -1,32 +1,32 @@
 # Daemon Architecture Design — RagCode MCP
 
-**Data:** 2026-03-07
-**Status:** Aprobat
+**Date:** 2026-03-07
+**Status:** Approved
 **Branch:** TBD
 
-## Problema
+## Problem
 
-Arhitectura curentă leagă procesul MASTER (Qdrant, Ollama, indexer) de stdin-ul primului IDE care l-a lansat.
+The current architecture ties the MASTER process (Qdrant, Ollama, indexer) to the stdin of the first IDE that launched it.
 
-- IDE1 pornește `rag-code-mcp` → devine MASTER (Stdio + HTTP :3000)
-- IDE2 pornește `rag-code-mcp` → detect port 3000 ocupat → intră în PROXY (Stdio→HTTP cu SSE parsing)
-- IDE1 se închide → stdin se închide → **context canceled → TOTUL moare**
+- IDE1 starts `rag-code-mcp` → becomes MASTER (Stdio + HTTP :3000)
+- IDE2 starts `rag-code-mcp` → detects port 3000 occupied → enters PROXY mode (Stdio→HTTP with SSE parsing)
+- IDE1 closes → stdin closes → **context canceled → EVERYTHING dies**
 
-Probleme suplimentare:
-- SSE parsing complex și fragil (extractSSEPayload, sessionid, handshake)
-- Port conflicts pe :3000
-- Indexare se oprește la închiderea IDE-ului
-- Index progress invizibil între instanțe
+Additional problems:
+- Complex and fragile SSE parsing (`extractSSEPayload`, sessionid, handshake)
+- Port conflicts on :3000
+- Indexing stops when IDE closes
+- Index progress invisible between instances
 
-## Soluția: Daemon + Unix Socket + Adaptorii Thin
+## Solution: Daemon + Unix Socket + Thin Adapters
 
-### Principiu
+### Principle
 
-Un singur binary (`rag-code-mcp`) cu două moduri:
-- **Fără flag** (default) → Adapter Stdio: verifică/pornește daemon, bridge stdin↔socket
-- **`--daemon`** → Daemon: proces persistent cu Qdrant, Ollama, Engine, MCP Server
+A single binary (`rag-code-mcp`) with two modes:
+- **No flag** (default) → Stdio Adapter: checks/starts daemon, bridges stdin↔socket
+- **`--daemon`** → Daemon: persistent process with Qdrant, Ollama, Engine, MCP Server
 
-### Diagrama proceselor
+### Process Diagram
 
 ```
 ┌──────────┐   ┌──────────┐   ┌──────────┐
@@ -47,45 +47,45 @@ Un singur binary (`rag-code-mcp`) cu două moduri:
      │   DAEMON (1 inst) │
      │                   │         ┌────────────────┐
      │  MCP Server       │◄────────│ curl / Python  │
-     │  Engine           │  HTTP   │ (opțional)     │
+     │  Engine           │  HTTP   │ (optional)     │
      │  Ollama (1 conn)  │ :3000   └────────────────┘
      │  Qdrant (1 conn)  │
      └───────────────────┘
 ```
 
-## Secțiunea 1: Arhitectura Generală
+## Section 1: General Architecture
 
-### Fișierele daemon-ului
+### Daemon Files
 
-| Fișier | Scop |
-|--------|------|
+| File | Purpose |
+|------|---------|
 | `~/.ragcode/daemon.sock` | Unix domain socket |
-| `~/.ragcode/daemon.pid` | PID + versiunea procesului daemon |
-| `~/.ragcode/daemon.lock` | File lock pentru race condition la startup |
-| `~/.ragcode/logs/ragcode.log` | Log-uri daemon |
+| `~/.ragcode/daemon.pid` | PID + daemon process version |
+| `~/.ragcode/daemon.lock` | File lock for startup race condition |
+| `~/.ragcode/logs/ragcode.log` | Daemon logs |
 | `~/.ragcode/registry.json` | Workspace registry |
 
-### Fluxul de pornire Adapter
+### Adapter Startup Flow
 
-1. Verifică `~/.ragcode/daemon.pid` → PID există?
-2. PID viu? (`kill -0 PID`)
+1. Check `~/.ragcode/daemon.pid` → PID exists?
+2. PID alive? (`kill -0 PID`)
 3. Socket connect (`dial unix daemon.sock`)?
 4. `GET /health` → 200 OK?
-5. Versiune == a noastră?
-6. Oricare eșuează → cleanup + `StartDaemon()`
-7. Toate OK → intră în bridge mode
+5. Version == ours?
+6. Any step fails → cleanup + `StartDaemon()`
+7. All OK → enter bridge mode
 
-### Ce se elimină complet
+### What Gets Removed Entirely
 
 - `extractSSEPayload()` — SSE parsing
 - `PortIsOccupied()` — port scanning
-- `KillProcessOnPort()` — kill pe port
+- `KillProcessOnPort()` — kill on port
 - `QueryMasterVersion()` via JSON-RPC initialize
-- Skill `ragcode-sse` → rescris ca `ragcode-http`
+- Skill `ragcode-sse` → rewritten as `ragcode-http`
 
-## Secțiunea 2: Protocol & Lifecycle
+## Section 2: Protocol & Lifecycle
 
-### Comunicare: HTTP/1.1 peste Unix socket, JSON pur
+### Communication: HTTP/1.1 over Unix socket, pure JSON
 
 **Request (Adapter → Daemon):**
 ```http
@@ -123,7 +123,7 @@ GET /health → 200 OK
 
 ### X-Workspace-Hint Header
 
-Fiecare adapter captează CWD (Current Working Directory = workspace-ul IDE-ului) la pornire și-l trimite ca header `X-Workspace-Hint` cu fiecare request. Daemon-ul îl folosește ca fallback când tool-ul nu primește `file_path`.
+Each adapter captures CWD (Current Working Directory = IDE workspace) at startup and sends it as the `X-Workspace-Hint` header with every request. The daemon uses it as a fallback when the tool doesn't receive `file_path`.
 
 ### PID File Format
 
@@ -137,103 +137,103 @@ SOCKET=~/.ragcode/daemon.sock
 ### Daemon Lifecycle
 
 - **Start:** Health checks → Init Engine → Listen socket + HTTP → Write PID → Signal ready
-- **Running:** Servește cereri MCP concurent, indexare background, watchers
-- **Shutdown (SIGTERM):** Stop watchers → Finalizează in-flight (5s grace) → Close listeners → Remove socket + PID
-- **Crash (kill -9):** Socket + PID rămân pe disc → stale detection la următorul adapter
+- **Running:** Serves MCP requests concurrently, background indexing, watchers
+- **Shutdown (SIGTERM):** Stop watchers → Finalize in-flight requests (5s grace) → Close listeners → Remove socket + PID
+- **Crash (kill -9):** Socket + PID remain on disk → stale detection on next adapter startup
 
-### Idle Timeout (opțional)
+### Idle Timeout (optional)
 
 ```yaml
 daemon:
   idle_timeout: 0  # 0 = run forever (default)
 ```
 
-## Secțiunea 3: Restructurarea Codului
+## Section 3: Code Restructuring
 
-### Fișiere noi
+### New Files
 
-| Fișier | Linii ~est. | Rol |
-|--------|------------|-----|
-| `internal/daemon/daemon.go` | ~120 | Procesul greu — extras din main.go |
+| File | Est. Lines | Role |
+|------|-----------|------|
+| `internal/daemon/daemon.go` | ~120 | Heavy process — extracted from main.go |
 | `internal/daemon/health.go` | ~40 | Health endpoint JSON |
 | `internal/daemon/pidfile.go` | ~60 | Write/Read/Remove PID, stale detection |
-| `internal/adapter/adapter.go` | ~50 | Bridge stdin ↔ Unix socket (JSON pur) |
+| `internal/adapter/adapter.go` | ~50 | Bridge stdin ↔ Unix socket (pure JSON) |
 | `internal/adapter/lifecycle.go` | ~80 | EnsureDaemon, StartDaemon, StopDaemon |
 
-### Fișiere modificate
+### Modified Files
 
-| Fișier | Schimbare |
-|--------|-----------|
-| `cmd/rag-code-mcp/main.go` | Simplificat: 365→~60 linii, doar decide mod |
-| `.agent/skills/ragcode-sse/` | Rescris ca ragcode-http |
-| `ARCHITECTURE.md` | Actualizat |
+| File | Change |
+|------|--------|
+| `cmd/rag-code-mcp/main.go` | Simplified: 365→~60 lines, only decides mode |
+| `.agent/skills/ragcode-sse/` | Rewritten as ragcode-http |
+| `ARCHITECTURE.md` | Updated |
 
-### Fișiere șterse
+### Deleted Files
 
-| Fișier | Motiv |
-|--------|-------|
-| `internal/proxy/portutil.go` | Înlocuit de adapter/lifecycle.go |
-| `internal/proxy/proxy.go` | Înlocuit de adapter/adapter.go |
-| `internal/proxy/proxy_test.go` | Teste pentru cod șters |
+| File | Reason |
+|------|--------|
+| `internal/proxy/portutil.go` | Replaced by adapter/lifecycle.go |
+| `internal/proxy/proxy.go` | Replaced by adapter/adapter.go |
+| `internal/proxy/proxy_test.go` | Tests for deleted code |
 
-### Ce NU se schimbă
+### What Does NOT Change
 
-- `internal/service/engine/` — zero schimbări
-- `internal/service/tools/` — zero schimbări
-- `internal/service/search/` — zero schimbări
-- `pkg/indexer/` — zero schimbări
-- `pkg/parser/*` — zero schimbări
-- `pkg/storage/` — zero schimbări
-- `pkg/workspace/` — zero schimbări
-- `internal/config/`, `internal/logger/`, `internal/healthcheck/` — zero schimbări
+- `internal/service/engine/` — zero changes
+- `internal/service/tools/` — zero changes
+- `internal/service/search/` — zero changes
+- `pkg/indexer/` — zero changes
+- `pkg/parser/*` — zero changes
+- `pkg/storage/` — zero changes
+- `pkg/workspace/` — zero changes
+- `internal/config/`, `internal/logger/`, `internal/healthcheck/` — zero changes
 
-### Impact net: ~-50 linii (mai puțin cod total)
+### Net impact: ~-50 lines (less total code)
 
-## Secțiunea 4: Error Handling, Testing & Migrare
+## Section 4: Error Handling, Testing & Migration
 
-### Scenarii de eroare
+### Error Scenarios
 
-| Scenariul | Recovery |
-|-----------|----------|
+| Scenario | Recovery |
+|----------|---------|
 | Daemon crash | Stale detection → cleanup → restart |
-| Ollama down | Circuit breaker existent funcționează |
-| Qdrant down | Eroare JSON-RPC → IDE vede eroarea |
-| Socket file șters | Connect fail → kill PID → restart |
-| 2 adaptori pornesc simultan | flock() pe daemon.lock |
+| Ollama down | Existing circuit breaker works |
+| Qdrant down | JSON-RPC error → IDE sees the error |
+| Socket file deleted | Connect fail → kill PID → restart |
+| 2 adapters start simultaneously | flock() on daemon.lock |
 | Upgrade (adapter v2, daemon v1) | Kill daemon v1 → start v2 |
 
-### Race condition protection
+### Race Condition Protection
 
-`daemon.lock` cu `syscall.Flock(LOCK_EX)` — doar un adapter verifică/pornește daemon-ul.
+`daemon.lock` with `syscall.Flock(LOCK_EX)` — only one adapter checks/starts the daemon.
 
 ### Testing
 
-**Teste unitare noi:**
+**New unit tests:**
 - `internal/daemon/pidfile_test.go`
 - `internal/daemon/health_test.go`
 - `internal/adapter/adapter_test.go`
 - `internal/adapter/lifecycle_test.go`
 
-**Teste de integrare:**
+**Integration tests:**
 - `TestDaemonStartAndBridge`
 - `TestMultipleAdapters`
 - `TestDaemonSurvivesAdapterDeath`
 - `TestDaemonUpgrade`
 - `TestStaleDaemonCleanup`
 
-### Migrare
+### Migration
 
-1. Implementare pe feature branch
-2. Merge pe dev — zero breaking changes (implicit backward compatible)
+1. Implementation on feature branch
+2. Merge to dev — zero breaking changes (implicitly backward compatible)
 3. Update skills
-4. Cleanup final
+4. Final cleanup
 
-### Configurare nouă (config.yaml)
+### New Configuration (config.yaml)
 
 ```yaml
 daemon:
   socket_path: ""             # default: ~/.ragcode/daemon.sock
   http_host: 127.0.0.1        # bind only to loopback by default (secure local access)
-  http_port: 3000             # HTTP on http_host:port; 0 = dezactivat. Pentru expunere externă (ex. 0.0.0.0) e necesar hardening (auth, TLS) și opt-in explicit.
+  http_port: 3000             # HTTP on http_host:port; 0 = disabled. For external exposure (e.g. 0.0.0.0) hardening (auth, TLS) is required and must be explicitly opted in.
   idle_timeout: 0             # 0 = run forever
 ```

--- a/docs/plans/2026-03-07-indexing-overhaul-design.md
+++ b/docs/plans/2026-03-07-indexing-overhaul-design.md
@@ -90,24 +90,25 @@ watchdog goroutine (1 single):   ← 60s interval
   "state": "running",
   "global_percent": 47,
   "current_language": "go",
-  "languages_queued": ["md", "go", "python", "php", "html"],
+  "job_id": "abc123-1741348800000000000",
   "languages": {
-    "md": { "done": 120, "total": 120, "percent": 100, "state": "completed" },
-    "go": { "done": 234, "total": 500, "percent": 46,  "state": "running"   },
-    "py": { "done": 0,   "total": 89,  "percent": 0,   "state": "pending"   }
+    "md": { "total_files": 120, "done_files": 120, "percent": 100, "updated_at": "2026-03-07T12:02:00Z" },
+    "go": { "total_files": 500, "done_files": 234, "percent": 46,  "updated_at": "2026-03-07T12:04:10Z" },
+    "py": { "total_files": 89,  "done_files": 0,   "percent": 0,   "updated_at": "2026-03-07T12:05:00Z" }
   },
   "started_at": "2026-03-07T12:00:00Z",
-  "updated_at": "2026-03-07T12:05:23Z",
-  "error": ""
+  "updated_at": "2026-03-07T12:05:23Z"
 }
 ```
 
-### Workspace Serialization
+### Workspace Concurrency
 
-- `indexingJobs sync.Map` remains for detecting an active job
-- If indexing is requested for an already-active workspace → rejected immediately (existing behavior)
-- If indexing is requested for another workspace while one is active → rejected with clear message (`ErrIndexingBusy`)
-- No queue (YAGNI) — user can re-trigger after completion
+- `indexingJobs sync.Map` tracks active indexing jobs per workspace ID
+- If indexing is requested for an **already-active workspace** → deduplicated immediately (no-op)
+- Concurrent indexing across **different workspaces** is **allowed** — each workspace has its own job
+- When multiple workspaces index simultaneously, a warning is logged at engine level since Ollama
+  model-runner serializes embed requests anyway (implicit Ollama-level queuing)
+- No global serialization lock — YAGNI; user can re-trigger completion independently per workspace
 
 ### Logging Standard
 

--- a/docs/plans/2026-03-07-indexing-overhaul-design.md
+++ b/docs/plans/2026-03-07-indexing-overhaul-design.md
@@ -8,78 +8,78 @@
 
 ## Problem
 
-### Bug 1 — Progress inaccurat (`last_percent`)
+### Bug 1 — Inaccurate Progress (`last_percent`)
 
-`state.json` conține câmpul `last_percent` care este **per-limbaj**, nu global.
-La fiecare limbaj nou, progresul se resetează de la 0 la 100, independent.
+`state.json` contains the `last_percent` field which is **per-language**, not global.
+For each new language, the progress resets from 0 to 100, independently.
 
-**Fluxul buggy:**
+**Buggy flow:**
 ```
 engine.IndexWorkspace:
-  state.json ← last_percent=1         (start global)
+  state.json ← last_percent=1         (global start)
 
   lang="md":
     indexer ← LoadState → last_percent=1
-    procesează fișiere → last_percent=46, 87, 100 (salvat periodic)
+    processes files → last_percent=46, 87, 100 (saved periodically)
     final → state.json: last_percent=100
 
   lang="go":
-    indexer ← LoadState → last_percent=100  (preia valoarea de la md!)
-    procesează fișiere → last_percent=3, 5, 8... (RESET!)
-    search vede 5% → "indexare întreruptă" fals pozitiv
+    indexer ← LoadState → last_percent=100  (picks up value from md!)
+    processes files → last_percent=3, 5, 8... (RESET!)
+    search sees 5% → "indexing interrupted" false positive
 ```
 
-**Efecte observate:**
-- Căutarea refuza indexarea la >80% md cu mesaj de "indexare în progres" fără procent real
-- `last_percent` se reseta între limbaje confuzând logica de auto-resume
-- `progressStore` in-memory era corect dar nu persista suficient de des pe disk
+**Observed effects:**
+- Search refused indexing at >80% md with "indexing in progress" message without real percentage
+- `last_percent` reset between languages confusing the auto-resume logic
+- `progressStore` in-memory was correct but did not persist to disk frequently enough
 
-### Bug 2 — Goroutine complexity nedebuggabilă
+### Bug 2 — Undebuggable Goroutine Complexity
 
-`globalIndexSemaphore` (package-level var) creează o concurență greu de urmărit:
-- N file workers per apel `IndexWorkspace`
-- 1 periodic save goroutine per apel (5 limbaje → 5 goroutine secvențiale)
-- 1 stall watchdog goroutine per apel
-- Workers partajează semaphore-ul global → comportament non-determinist dacă 2 workspace-uri indexează simultan
+`globalIndexSemaphore` (package-level var) creates concurrency that is hard to trace:
+- N file workers per `IndexWorkspace` call
+- 1 periodic save goroutine per call (5 languages → 5 sequential goroutines)
+- 1 stall watchdog goroutine per call
+- Workers share the global semaphore → non-deterministic behavior if 2 workspaces index simultaneously
 
-Deoarece `IndexItems` are `numWorkers=1` (embed-ul e serial la Ollama), paralelismul file workers nu aduce câștig real de performanță, dar adaugă complexitate maximă.
+Since `IndexItems` has `numWorkers=1` (embedding is serial at Ollama), file worker parallelism provides no real performance gain, but adds maximum complexity.
 
 ---
 
-## Soluție
+## Solution
 
-### Principii de design
+### Design Principles
 
-1. **O singură sursă de adevăr pentru progres** — `index_status.json` (nu `state.json`)
-2. **3 goroutine fixe** — indiferent de câte limbaje există
-3. **1 workspace la un moment dat** — simplu, determinist, ușor de depanat
-4. **Verbosity prin log levels** — per-fișier la Debug, per-limbaj la Info, erori la Warn/Error
+1. **Single source of truth for progress** — `index_status.json` (not `state.json`)
+2. **3 fixed goroutines** — regardless of how many languages exist
+3. **1 workspace at a time** — simple, deterministic, easy to debug
+4. **Verbosity via log levels** — per-file at Debug, per-language at Info, errors at Warn/Error
 
-### Arhitectura nouă
+### New Architecture
 
 ```
 StartIndexingAsync(ws):   ← 1 goroutine
-  1. Pre-scan ALL languages → total_files_global (sumă)
-  2. for lang in languages:          ← secvențial
-       for file in lang_files:       ← secvențial (for loop simplu, fără pool)
+  1. Pre-scan ALL languages → total_files_global (sum)
+  2. for lang in languages:          ← sequential
+       for file in lang_files:       ← sequential (simple for loop, no pool)
          IndexFile(file)             ← AST → embed → Qdrant
          progress++
          lang_pct  = progress_in_lang / lang_files * 100
          global_pct = progress_total / total_files * 100
          ← debounced write (500ms)
 
-save goroutine (1 singur):   ← debounced 500ms
+save goroutine (1 single):   ← debounced 500ms
   index_status.json ← global_pct + per-lang breakdown
 
-watchdog goroutine (1 singur):   ← 60s interval
-  dacă nu embed activity → Warn + restart Ollama dacă necesar
+watchdog goroutine (1 single):   ← 60s interval
+  if no embed activity → Warn + restart Ollama if needed
 ```
 
-### Fișiere de stare
+### State Files
 
-| Fișier | Rol | Câmpuri relevante |
+| File | Role | Relevant Fields |
 |---|---|---|
-| `state.json` | File tracking (modtime/size) | `files{}` — **fără `last_percent`** |
+| `state.json` | File tracking (modtime/size) | `files{}` — **no `last_percent`** |
 | `index_status.json` | Progress tracking | `global_percent`, `languages{}`, `state`, `current_language` |
 
 **`index_status.json` format:**
@@ -102,25 +102,25 @@ watchdog goroutine (1 singur):   ← 60s interval
 }
 ```
 
-### Serialitate workspace-uri
+### Workspace Serialization
 
-- `indexingJobs sync.Map` rămâne pentru a detecta job activ
-- Dacă se cere indexare pentru un workspace deja activ → respins imediat (comportament existent)
-- Dacă se cere indexare pentru alt workspace când unul e activ → respins cu mesaj clar (`ErrIndexingBusy`)
-- Nu există coadă (YAGNI) — utilizatorul poate re-triggera după terminare
+- `indexingJobs sync.Map` remains for detecting an active job
+- If indexing is requested for an already-active workspace → rejected immediately (existing behavior)
+- If indexing is requested for another workspace while one is active → rejected with clear message (`ErrIndexingBusy`)
+- No queue (YAGNI) — user can re-trigger after completion
 
-### Standard de logging
+### Logging Standard
 
 **Format:** `[IDX] ws=<name> lang=<lang> [<n>/<total>] <file> (<lang_pct>%) global=<global_pct>%`
 
-| Nivel | Conținut | Default vizibil |
+| Level | Content | Visible by Default |
 |---|---|---|
-| `Debug` | Per fișier processat | ❌ (MCP_LOG_LEVEL=debug) |
-| `Info` | Start/Done limbaj, global complete | ✅ |
-| `Warn` | Eroare fișier individual, stall detectat | ✅ |
-| `Error` | Eșec limbaj, Ollama/Qdrant down | ✅ |
+| `Debug` | Per file processed | ❌ (MCP_LOG_LEVEL=debug) |
+| `Info` | Language start/done, global complete | ✅ |
+| `Warn` | Individual file error, stall detected | ✅ |
+| `Error` | Language failure, Ollama/Qdrant down | ✅ |
 
-**Exemple Info (default):**
+**Info examples (default):**
 ```
 [IDX] ws=rag-code-mcp  ▶ starting 5 languages (total files: 1247)
 [IDX] ws=rag-code-mcp lang=md     ✅ DONE 120 files in 0m45s (global=10%)
@@ -128,7 +128,7 @@ watchdog goroutine (1 singur):   ← 60s interval
 [IDX] ws=rag-code-mcp  ✅ COMPLETE all 5 languages in 8m42s
 ```
 
-**Exemple Debug (MCP_LOG_LEVEL=debug):**
+**Debug examples (MCP_LOG_LEVEL=debug):**
 ```
 [IDX] ws=rag-code-mcp lang=go [  1/500] main.go     ( 0%) global=10%
 [IDX] ws=rag-code-mcp lang=go [234/500] engine.go   (46%) global=23%
@@ -136,22 +136,22 @@ watchdog goroutine (1 singur):   ← 60s interval
 
 ---
 
-## Ce NU se schimbă
+## What Does NOT Change
 
-- `globalIndexSemaphore` — **eliminat** (nu aduce beneficiu real cu embed serial)
-- `IndexItems` numWorkers=1 — rămâne (Ollama e serial oricum)
-- Circuit breaker Ollama — rămâne (util)
-- `EnsureLoaded` la start limbaj — rămâne
-- Periodic state.json save (file tracking) — rămâne
+- `globalIndexSemaphore` — **removed** (provides no real benefit with serial embedding)
+- `IndexItems` numWorkers=1 — remains (Ollama is serial anyway)
+- Ollama circuit breaker — remains (useful)
+- `EnsureLoaded` at language start — remains
+- Periodic state.json save (file tracking) — remains
 
-## Ce se schimbă
+## What Changes
 
-| Componentă | Schimbare |
+| Component | Change |
 |---|---|
-| `pkg/indexer/service.go` | Elimină `globalIndexSemaphore` + file worker pool → for loop simplu |
-| `pkg/indexer/service.go` | Elimină `state.SetLastPercent()` din file processing |
-| `pkg/indexer/state.go` | Elimină câmpul `LastPercent` din `State` struct |
-| `internal/service/engine/index_progress.go` | Adaugă `global_percent` calculat + flush debounced la `index_status.json` |
-| `internal/service/engine/engine.go` | Pre-scan total files înainte de loop; search logic citește `index_status.json` |
-| `internal/service/engine/engine.go` | Adaugă `ErrIndexingBusy` pentru al doilea workspace |
-| Toate fișierele de indexare | `log.Printf` → `logger.Instance.*` cu format standardizat `[IDX]` |
+| `pkg/indexer/service.go` | Remove `globalIndexSemaphore` + file worker pool → simple for loop |
+| `pkg/indexer/service.go` | Remove `state.SetLastPercent()` from file processing |
+| `pkg/indexer/state.go` | Remove `LastPercent` field from `State` struct |
+| `internal/service/engine/index_progress.go` | Add computed `global_percent` + debounced flush to `index_status.json` |
+| `internal/service/engine/engine.go` | Pre-scan total files before loop; search logic reads `index_status.json` |
+| `internal/service/engine/engine.go` | Add `ErrIndexingBusy` for second workspace |
+| All indexing files | `log.Printf` → `logger.Instance.*` with standardized `[IDX]` format |

--- a/docs/plans/2026-03-07-indexing-overhaul-design.md
+++ b/docs/plans/2026-03-07-indexing-overhaul-design.md
@@ -1,0 +1,157 @@
+# Multi-Collection Indexing Overhaul — Design Document
+
+**Date:** 2026-03-07  
+**Status:** Approved  
+**Scope:** `pkg/indexer/`, `internal/service/engine/`
+
+---
+
+## Problem
+
+### Bug 1 — Progress inaccurat (`last_percent`)
+
+`state.json` conține câmpul `last_percent` care este **per-limbaj**, nu global.
+La fiecare limbaj nou, progresul se resetează de la 0 la 100, independent.
+
+**Fluxul buggy:**
+```
+engine.IndexWorkspace:
+  state.json ← last_percent=1         (start global)
+
+  lang="md":
+    indexer ← LoadState → last_percent=1
+    procesează fișiere → last_percent=46, 87, 100 (salvat periodic)
+    final → state.json: last_percent=100
+
+  lang="go":
+    indexer ← LoadState → last_percent=100  (preia valoarea de la md!)
+    procesează fișiere → last_percent=3, 5, 8... (RESET!)
+    search vede 5% → "indexare întreruptă" fals pozitiv
+```
+
+**Efecte observate:**
+- Căutarea refuza indexarea la >80% md cu mesaj de "indexare în progres" fără procent real
+- `last_percent` se reseta între limbaje confuzând logica de auto-resume
+- `progressStore` in-memory era corect dar nu persista suficient de des pe disk
+
+### Bug 2 — Goroutine complexity nedebuggabilă
+
+`globalIndexSemaphore` (package-level var) creează o concurență greu de urmărit:
+- N file workers per apel `IndexWorkspace`
+- 1 periodic save goroutine per apel (5 limbaje → 5 goroutine secvențiale)
+- 1 stall watchdog goroutine per apel
+- Workers partajează semaphore-ul global → comportament non-determinist dacă 2 workspace-uri indexează simultan
+
+Deoarece `IndexItems` are `numWorkers=1` (embed-ul e serial la Ollama), paralelismul file workers nu aduce câștig real de performanță, dar adaugă complexitate maximă.
+
+---
+
+## Soluție
+
+### Principii de design
+
+1. **O singură sursă de adevăr pentru progres** — `index_status.json` (nu `state.json`)
+2. **3 goroutine fixe** — indiferent de câte limbaje există
+3. **1 workspace la un moment dat** — simplu, determinist, ușor de depanat
+4. **Verbosity prin log levels** — per-fișier la Debug, per-limbaj la Info, erori la Warn/Error
+
+### Arhitectura nouă
+
+```
+StartIndexingAsync(ws):   ← 1 goroutine
+  1. Pre-scan ALL languages → total_files_global (sumă)
+  2. for lang in languages:          ← secvențial
+       for file in lang_files:       ← secvențial (for loop simplu, fără pool)
+         IndexFile(file)             ← AST → embed → Qdrant
+         progress++
+         lang_pct  = progress_in_lang / lang_files * 100
+         global_pct = progress_total / total_files * 100
+         ← debounced write (500ms)
+
+save goroutine (1 singur):   ← debounced 500ms
+  index_status.json ← global_pct + per-lang breakdown
+
+watchdog goroutine (1 singur):   ← 60s interval
+  dacă nu embed activity → Warn + restart Ollama dacă necesar
+```
+
+### Fișiere de stare
+
+| Fișier | Rol | Câmpuri relevante |
+|---|---|---|
+| `state.json` | File tracking (modtime/size) | `files{}` — **fără `last_percent`** |
+| `index_status.json` | Progress tracking | `global_percent`, `languages{}`, `state`, `current_language` |
+
+**`index_status.json` format:**
+```json
+{
+  "workspace_id": "abc123",
+  "workspace_root": "/home/user/project",
+  "state": "running",
+  "global_percent": 47,
+  "current_language": "go",
+  "languages_queued": ["md", "go", "python", "php", "html"],
+  "languages": {
+    "md": { "done": 120, "total": 120, "percent": 100, "state": "completed" },
+    "go": { "done": 234, "total": 500, "percent": 46,  "state": "running"   },
+    "py": { "done": 0,   "total": 89,  "percent": 0,   "state": "pending"   }
+  },
+  "started_at": "2026-03-07T12:00:00Z",
+  "updated_at": "2026-03-07T12:05:23Z",
+  "error": ""
+}
+```
+
+### Serialitate workspace-uri
+
+- `indexingJobs sync.Map` rămâne pentru a detecta job activ
+- Dacă se cere indexare pentru un workspace deja activ → respins imediat (comportament existent)
+- Dacă se cere indexare pentru alt workspace când unul e activ → respins cu mesaj clar (`ErrIndexingBusy`)
+- Nu există coadă (YAGNI) — utilizatorul poate re-triggera după terminare
+
+### Standard de logging
+
+**Format:** `[IDX] ws=<name> lang=<lang> [<n>/<total>] <file> (<lang_pct>%) global=<global_pct>%`
+
+| Nivel | Conținut | Default vizibil |
+|---|---|---|
+| `Debug` | Per fișier processat | ❌ (MCP_LOG_LEVEL=debug) |
+| `Info` | Start/Done limbaj, global complete | ✅ |
+| `Warn` | Eroare fișier individual, stall detectat | ✅ |
+| `Error` | Eșec limbaj, Ollama/Qdrant down | ✅ |
+
+**Exemple Info (default):**
+```
+[IDX] ws=rag-code-mcp  ▶ starting 5 languages (total files: 1247)
+[IDX] ws=rag-code-mcp lang=md     ✅ DONE 120 files in 0m45s (global=10%)
+[IDX] ws=rag-code-mcp lang=go     ✅ DONE 500 files in 4m12s (global=50%)
+[IDX] ws=rag-code-mcp  ✅ COMPLETE all 5 languages in 8m42s
+```
+
+**Exemple Debug (MCP_LOG_LEVEL=debug):**
+```
+[IDX] ws=rag-code-mcp lang=go [  1/500] main.go     ( 0%) global=10%
+[IDX] ws=rag-code-mcp lang=go [234/500] engine.go   (46%) global=23%
+```
+
+---
+
+## Ce NU se schimbă
+
+- `globalIndexSemaphore` — **eliminat** (nu aduce beneficiu real cu embed serial)
+- `IndexItems` numWorkers=1 — rămâne (Ollama e serial oricum)
+- Circuit breaker Ollama — rămâne (util)
+- `EnsureLoaded` la start limbaj — rămâne
+- Periodic state.json save (file tracking) — rămâne
+
+## Ce se schimbă
+
+| Componentă | Schimbare |
+|---|---|
+| `pkg/indexer/service.go` | Elimină `globalIndexSemaphore` + file worker pool → for loop simplu |
+| `pkg/indexer/service.go` | Elimină `state.SetLastPercent()` din file processing |
+| `pkg/indexer/state.go` | Elimină câmpul `LastPercent` din `State` struct |
+| `internal/service/engine/index_progress.go` | Adaugă `global_percent` calculat + flush debounced la `index_status.json` |
+| `internal/service/engine/engine.go` | Pre-scan total files înainte de loop; search logic citește `index_status.json` |
+| `internal/service/engine/engine.go` | Adaugă `ErrIndexingBusy` pentru al doilea workspace |
+| Toate fișierele de indexare | `log.Printf` → `logger.Instance.*` cu format standardizat `[IDX]` |

--- a/docs/plans/2026-03-07-indexing-overhaul.md
+++ b/docs/plans/2026-03-07-indexing-overhaul.md
@@ -1,0 +1,641 @@
+# Multi-Collection Indexing Overhaul — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix progress tracking bugs in multi-language indexing and simplify the goroutine model for debuggability.
+
+**Architecture:** Replace the dual `state.json`/`progressStore` truth sources with a single `index_status.json` persisted by a debounced save goroutine. Remove `globalIndexSemaphore` and file worker pools in favor of a simple sequential for-loop per language.
+
+**Tech Stack:** Go, `log/slog` via `logger.Instance`, `sync.Mutex`, `time.Ticker` for debounced writes.
+
+**Design doc:** `docs/plans/2026-03-07-indexing-overhaul-design.md`
+
+**Branch:** `feat/indexing-overhaul`
+
+---
+
+## Overview of changes
+
+```
+pkg/indexer/state.go           — remove LastPercent field
+pkg/indexer/service.go         — remove globalIndexSemaphore + worker pool → simple for loop
+internal/service/engine/index_progress.go  — add global_percent + debounced disk flush
+internal/service/engine/engine.go          — pre-scan, search reads index_status.json, ErrIndexingBusy
+```
+
+Tests to verify after each task: `go test ./pkg/indexer/... ./internal/service/engine/...`
+
+---
+
+## Task 1: Remove `LastPercent` from `State` struct
+
+**Files:**
+- Modify: `pkg/indexer/state.go`
+- Modify: `pkg/indexer/service.go` (remove `state.SetLastPercent(pct)` calls)
+- Test: `pkg/indexer/service_test.go`
+
+### Step 1: Write failing test that verifies State has no LastPercent
+
+```go
+// In pkg/indexer/state_test.go (create if missing)
+func TestStateHasNoLastPercent(t *testing.T) {
+    s := NewState()
+    data, err := json.Marshal(s)
+    require.NoError(t, err)
+    // LastPercent must NOT be serialized
+    assert.NotContains(t, string(data), "last_percent")
+}
+```
+
+### Step 2: Run test — expect FAIL (field exists)
+
+```bash
+go test ./pkg/indexer/... -run TestStateHasNoLastPercent -v
+```
+Expected: FAIL — `last_percent` present in JSON.
+
+### Step 3: Remove `LastPercent` from State
+
+In `pkg/indexer/state.go`:
+- Remove field `LastPercent int \`json:"last_percent"\`` from `State` struct
+- Remove method `SetLastPercent(percent int)`
+
+### Step 4: Remove all calls to `SetLastPercent`
+
+In `pkg/indexer/service.go`, remove:
+```go
+state.SetLastPercent(pct) // line ~316
+```
+Also remove the `pct` variable calculation above it (lines ~311-314).
+
+In `internal/service/engine/engine.go`, remove the two blocks:
+```go
+// Remove this:
+if state, err := indexer.LoadState(statePath); err == nil {
+    state.SetLastPercent(1)
+    _ = state.Save(statePath)
+}
+// And this (end of IndexWorkspace):
+if state, err := indexer.LoadState(statePath); err == nil {
+    state.SetLastPercent(100)
+    _ = state.Save(statePath)
+}
+```
+
+### Step 5: Run tests
+
+```bash
+go test ./pkg/indexer/... ./internal/service/engine/... -v
+```
+Expected: all pass (or only pre-existing failures).
+
+### Step 6: Commit
+
+```bash
+git add pkg/indexer/state.go pkg/indexer/service.go internal/service/engine/engine.go
+git commit -m "refactor(indexer): remove LastPercent from State — progress moves to index_status.json"
+```
+
+---
+
+## Task 2: Remove `globalIndexSemaphore` + file worker pool
+
+**Files:**
+- Modify: `pkg/indexer/service.go`
+
+The goal: replace the worker-pool goroutines with a simple `for _, path := range changedFiles { IndexFile(...) }` loop.
+
+### Step 1: Write test verifying sequential file processing
+
+```go
+// In pkg/indexer/service_test.go
+func TestIndexWorkspaceIsSequential(t *testing.T) {
+    // This test verifies that IndexWorkspace calls Progress callback
+    // in strictly ascending order (sequential = no out-of-order increments).
+    var calls []int
+    var mu sync.Mutex
+    opts := Options{
+        Language: "go",
+        Progress: func(done, total int) {
+            mu.Lock()
+            calls = append(calls, done)
+            mu.Unlock()
+        },
+    }
+    // Use a mock store + embedder that return immediately
+    // ... (use existing test helpers from service_test.go)
+    // Assert calls are strictly [1, 2, 3, ...]
+    for i := 1; i < len(calls); i++ {
+        assert.Equal(t, calls[i-1]+1, calls[i], "progress calls must be sequential")
+    }
+}
+```
+
+### Step 2: Run test — verify it passes already or documents current behavior
+
+```bash
+go test ./pkg/indexer/... -run TestIndexWorkspaceIsSequential -v
+```
+
+### Step 3: Replace worker pool with simple loop
+
+In `pkg/indexer/service.go`, replace the section starting at `// 4. Process changed files using the global semaphore`:
+
+**Remove:**
+```go
+var globalIndexSemaphore = func() chan struct{} { ... }()  // entire package-level var
+
+// In IndexWorkspace, remove:
+numFileWorkers := cap(globalIndexSemaphore)
+filePaths := make(chan string, totalFiles)
+for _, p := range changedFiles { filePaths <- p }
+close(filePaths)
+
+var (
+    fileWg    sync.WaitGroup
+    errMu     sync.Mutex
+    fileErrs  []string
+    doneFiles atomic.Int64
+)
+
+// ... the entire save+watchdog goroutine block ...
+// ... the worker goroutine for loop ...
+fileWg.Wait()
+close(saveStop)
+```
+
+**Add (simple loop):**
+```go
+var fileErrs []string
+doneFiles := 0
+
+// Dedicated periodic-save + stall watchdog goroutine
+saveStop := make(chan struct{})
+go func() {
+    saveTicker := time.NewTicker(10 * time.Second)
+    stallTicker := time.NewTicker(60 * time.Second)
+    defer saveTicker.Stop()
+    defer stallTicker.Stop()
+    stallCount := 0
+    lastDone := 0
+    for {
+        select {
+        case <-saveTicker.C:
+            if err := state.Save(statePath); err != nil {
+                logger.Instance.Warn("[IDX] ws=%s lang=%s periodic state save failed: %v", wsName, opts.Language, err)
+            }
+        case <-stallTicker.C:
+            if doneFiles < totalFiles && doneFiles == lastDone {
+                stallCount++
+                logger.Instance.Warn("[IDX] ws=%s lang=%s ⚠️ STALL: no progress for 60s [%d/%d] (stall #%d)",
+                    wsName, opts.Language, doneFiles, totalFiles, stallCount)
+                if stallCount >= 2 {
+                    if err := healthcheck.PingOllama(""); err != nil {
+                        logger.Instance.Error("[IDX] ws=%s lang=%s ❌ Ollama unresponsive: %v — forcing restart", wsName, opts.Language, err)
+                    }
+                    attemptOllamaRestart()
+                }
+            } else {
+                stallCount = 0
+            }
+            lastDone = doneFiles
+        case <-saveStop:
+            return
+        }
+    }
+}()
+
+for _, path := range changedFiles {
+    doneFiles++
+    langPct := doneFiles * 100 / totalFiles
+
+    logger.Instance.Debug("[IDX] ws=%s lang=%s [%d/%d] %s (%d%%)",
+        wsName, opts.Language, doneFiles, totalFiles, filepath.Base(path), langPct)
+
+    if opts.Progress != nil {
+        opts.Progress(doneFiles, totalFiles)
+    }
+
+    _, indexErr := s.IndexFile(ctx, collection, path, state)
+    if indexErr != nil {
+        logger.Instance.Warn("[IDX] ws=%s lang=%s ⚠️ %s: %v",
+            wsName, opts.Language, filepath.Base(path), indexErr)
+        fileErrs = append(fileErrs, fmt.Sprintf("%s: %v", path, indexErr))
+    }
+}
+
+close(saveStop)
+```
+
+> Note: `wsName` needs to be passed in via `Options` struct (see Task 3).
+
+### Step 4: Add `WorkspaceName` to `Options`
+
+In `pkg/indexer/service.go` — `Options` struct, add:
+```go
+WorkspaceName string // for logging (basename of workspace root)
+```
+
+### Step 5: Remove unused imports
+
+Remove `sync/atomic`, `sync.WaitGroup` from `service.go` if no longer used.
+
+### Step 6: Run tests
+
+```bash
+go test ./pkg/indexer/... -v
+```
+
+### Step 7: Commit
+
+```bash
+git add pkg/indexer/service.go
+git commit -m "refactor(indexer): replace globalIndexSemaphore+worker pool with simple sequential loop"
+```
+
+---
+
+## Task 3: Add `global_percent` + debounced flush to `index_progress.go`
+
+**Files:**
+- Modify: `internal/service/engine/index_progress.go`
+- Modify: `internal/service/engine/index_progress_test.go`
+
+### Step 1: Write failing test for `globalPercent()`
+
+```go
+// In index_progress_test.go
+func TestProgressStoreGlobalPercent(t *testing.T) {
+    s := newProgressStore()
+    s.start("ws1", "/root", "job1", time.Now())
+    s.update("ws1", "md", 120, 120, time.Now())   // md: 100%
+    s.update("ws1", "go", 234, 500, time.Now())   // go: 46%
+
+    p := s.get("ws1", "")
+    require.NotNil(t, p)
+    // global = (120 + 234) / (120 + 500) * 100 = 354/620*100 = 57%
+    assert.Equal(t, 57, p.GlobalPercent)
+}
+```
+
+### Step 2: Run test — expect FAIL (field missing)
+
+```bash
+go test ./internal/service/engine/... -run TestProgressStoreGlobalPercent -v
+```
+
+### Step 3: Add `GlobalPercent` to `IndexProgress` and `CurrentLanguage`
+
+In `index_progress.go`, update `IndexProgress` struct:
+```go
+type IndexProgress struct {
+    JobID           string                           `json:"job_id"`
+    WorkspaceID     string                           `json:"workspace_id"`
+    WorkspaceRoot   string                           `json:"workspace_root"`
+    State           string                           `json:"state"`
+    GlobalPercent   int                              `json:"global_percent"`   // NEW
+    CurrentLanguage string                           `json:"current_language"` // NEW
+    LanguagesQueued []string                         `json:"languages_queued"` // NEW
+    StartedAt       time.Time                        `json:"started_at"`
+    CompletedAt     *time.Time                       `json:"completed_at,omitempty"`
+    Languages       map[string]IndexLanguageProgress `json:"languages,omitempty"`
+    UpdatedAt       time.Time                        `json:"updated_at"`
+    Error           string                           `json:"error,omitempty"`
+}
+```
+
+### Step 4: Add `globalPercent()` helper to `progressStore`
+
+```go
+// calcGlobalPercent computes global_percent as sum(done) / sum(total) * 100.
+// Call with s.mu held.
+func calcGlobalPercent(langs map[string]IndexLanguageProgress) int {
+    var totalDone, totalFiles int
+    for _, lp := range langs {
+        totalDone += lp.DoneFiles
+        totalFiles += lp.TotalFiles
+    }
+    if totalFiles == 0 {
+        return 0
+    }
+    pct := totalDone * 100 / totalFiles
+    if pct > 100 {
+        return 100
+    }
+    return pct
+}
+```
+
+Update `progressStore.update()` to set `GlobalPercent`:
+```go
+func (s *progressStore) update(workspaceID, lang string, done, total int, now time.Time) {
+    // ... existing code ...
+    p.Languages[lang] = IndexLanguageProgress{ ... }
+    p.GlobalPercent = calcGlobalPercent(p.Languages) // NEW
+    p.CurrentLanguage = lang                          // NEW
+    p.UpdatedAt = now
+}
+```
+
+### Step 5: Add debounced flush to `index_status.json`
+
+Add a `flushCh chan struct{}` to `progressStore` and a background flush goroutine:
+
+```go
+type progressStore struct {
+    mu      sync.Mutex
+    jobs    map[string]*IndexProgress
+    flushCh chan struct{} // signals debounced flush
+}
+
+func newProgressStore() *progressStore {
+    ps := &progressStore{
+        jobs:    map[string]*IndexProgress{},
+        flushCh: make(chan struct{}, 1),
+    }
+    go ps.runFlusher()
+    return ps
+}
+
+// runFlusher drains flushCh and persists all jobs debounced at 500ms.
+func (s *progressStore) runFlusher() {
+    for range s.flushCh {
+        time.Sleep(500 * time.Millisecond)
+        // Drain any pending signals during the sleep
+        for len(s.flushCh) > 0 {
+            <-s.flushCh
+        }
+        s.mu.Lock()
+        for _, p := range s.jobs {
+            if p.WorkspaceRoot != "" {
+                saveIndexStatus(p.WorkspaceRoot, p)
+            }
+        }
+        s.mu.Unlock()
+    }
+}
+
+// triggerFlush signals the flusher non-blockingly.
+func (s *progressStore) triggerFlush() {
+    select {
+    case s.flushCh <- struct{}{}:
+    default: // already pending, no need to queue another
+    }
+}
+```
+
+Call `s.triggerFlush()` at end of `update()`, `complete()`, `fail()`.
+
+### Step 6: Run tests
+
+```bash
+go test ./internal/service/engine/... -v
+```
+
+### Step 7: Commit
+
+```bash
+git add internal/service/engine/index_progress.go internal/service/engine/index_progress_test.go
+git commit -m "feat(engine): add global_percent + debounced index_status.json flush to progressStore"
+```
+
+---
+
+## Task 4: Pre-scan total files + search reads `index_status.json`
+
+**Files:**
+- Modify: `internal/service/engine/engine.go`
+
+### Step 1: Add `ErrIndexingBusy` error type
+
+```go
+// ErrIndexingBusy is returned when any workspace is currently being indexed
+// and a second workspace requests indexing (serialized by design).
+type ErrIndexingBusy struct {
+    ActiveWorkspaceRoot string
+}
+
+func (e *ErrIndexingBusy) Error() string {
+    return fmt.Sprintf("indexing busy: workspace %q is currently being indexed; try again after it completes", e.ActiveWorkspaceRoot)
+}
+```
+
+### Step 2: Add `WorkspaceName` to `indexer.Options` call in `engine.IndexWorkspace`
+
+Update the `e.indexer.IndexWorkspace(...)` call to pass workspace name:
+```go
+err := e.indexer.IndexWorkspace(ctx, wctx.Root, collection, indexer.Options{
+    Language:        lang,
+    WorkspaceName:   filepath.Base(wctx.Root), // NEW
+    ExcludePatterns: e.config.Workspace.ExcludePatterns,
+    Recreate:        recreate,
+    Progress:        progressCb,
+})
+```
+
+### Step 3: Add pre-scan for total files and set `LanguagesQueued`
+
+At the start of `engine.IndexWorkspace`, before the language loop, set queued languages:
+```go
+// Inform progressStore of the full language queue upfront
+if e.progress != nil {
+    e.progress.setLanguagesQueued(wctx.ID, languages)
+}
+
+// Log start
+wsName := filepath.Base(wctx.Root)
+logger.Instance.Info("[IDX] ws=%s ▶ starting %d languages", wsName, len(languages))
+```
+
+Add `setLanguagesQueued` to `progressStore`:
+```go
+func (s *progressStore) setLanguagesQueued(workspaceID string, langs []string) {
+    s.mu.Lock()
+    defer s.mu.Unlock()
+    if p, ok := s.jobs[workspaceID]; ok {
+        p.LanguagesQueued = langs
+    }
+}
+```
+
+### Step 4: Add per-language Info logs to `engine.IndexWorkspace`
+
+Wrap each language with start/done logs:
+```go
+for _, lang := range languages {
+    wsName := filepath.Base(wctx.Root)
+    logger.Instance.Info("[IDX] ws=%s lang=%s ▶ starting", wsName, lang)
+    langStart := time.Now()
+
+    // ... existing progressCb and indexer call ...
+
+    elapsed := time.Since(langStart)
+    if err != nil {
+        logger.Instance.Error("[IDX] ws=%s lang=%s ❌ FAILED in %s: %v", wsName, lang, elapsed.Round(time.Second), err)
+        indexErrors = append(indexErrors, fmt.Sprintf("%s: %v", lang, err))
+    } else {
+        // Get done files count from progressStore for the log
+        if pgs := e.progress.get(wctx.ID, ""); pgs != nil {
+            if lp, ok := pgs.Languages[lang]; ok {
+                logger.Instance.Info("[IDX] ws=%s lang=%s ✅ DONE %d files in %s (global=%d%%)",
+                    wsName, lang, lp.DoneFiles, elapsed.Round(time.Second), pgs.GlobalPercent)
+            }
+        }
+    }
+}
+
+// Log global complete
+logger.Instance.Info("[IDX] ws=%s ✅ COMPLETE all %d languages", wsName, len(languages))
+```
+
+### Step 5: Update search logic to read `index_status.json` for progress display
+
+In `engine.SearchCode` and `engine.HybridSearchCode`, replace the `indexer.LoadState` check:
+
+**Remove:**
+```go
+indexerStatePath := filepath.Join(wctx.Root, ".ragcode", "state.json")
+if idxState, sErr := indexer.LoadState(indexerStatePath); sErr == nil {
+    if idxState.LastPercent > 0 && idxState.LastPercent < 100 {
+        // ... auto-resume logic ...
+    }
+}
+```
+
+**Add:**
+```go
+// Check index_status.json for interrupted/in-progress indexing
+if p := e.GetIndexProgress(wctx.ID, wctx.Root); p != nil {
+    switch p.State {
+    case "running", "starting":
+        if _, ok := e.indexingJobs.Load(wctx.ID); !ok {
+            // Was running but process died — auto-resume
+            const resumeCooldown = 5 * time.Minute
+            now := time.Now()
+            if last, loaded := e.resumeAttempts.Load(wctx.ID); !loaded || now.Sub(last.(time.Time)) > resumeCooldown {
+                e.resumeAttempts.Store(wctx.ID, now)
+                logger.Instance.Info("[IDX] ws=%s interrupted at %d%% — auto-resuming", filepath.Base(wctx.Root), p.GlobalPercent)
+                e.StartIndexingAsync(wctx.Root, wctx.ID, nil, false)
+            }
+        }
+        logger.Instance.Info("[IDX] ws=%s in progress (%d%%) — searching available results", filepath.Base(wctx.Root), p.GlobalPercent)
+    }
+}
+```
+
+### Step 6: Run tests
+
+```bash
+go test ./internal/service/engine/... -v
+go test ./... 2>&1 | tail -20
+```
+
+### Step 7: Commit
+
+```bash
+git add internal/service/engine/engine.go
+git commit -m "feat(engine): pre-scan langs queue, search reads index_status.json for progress"
+```
+
+---
+
+## Task 5: Standardize all `log.Printf` → `logger.Instance` in indexer
+
+**Files:**
+- Modify: `pkg/indexer/service.go` (grep for remaining `log.Printf`)
+
+### Step 1: Find all non-standard log calls
+
+```bash
+grep -n "log\.Printf\|log\.Println\|fmt\.Printf" pkg/indexer/service.go
+```
+
+### Step 2: Replace each with `logger.Instance.*` using `[IDX]` prefix
+
+Pattern for replacements:
+- `log.Printf("[INFO] ...")` → `logger.Instance.Info("[IDX] ...")`
+- `log.Printf("[ERROR] ...")` → `logger.Instance.Error("[IDX] ...")`
+- `log.Printf("[DEBUG] ...")` → `logger.Instance.Debug("[IDX] ...")`
+
+Remove `"log"` from imports if no longer used.
+
+### Step 3: Remove unused imports from service.go
+
+```bash
+go build ./pkg/indexer/...
+```
+Fix any import errors.
+
+### Step 4: Run tests + build
+
+```bash
+go test ./pkg/indexer/... -v
+go build ./...
+```
+
+### Step 5: Commit
+
+```bash
+git add pkg/indexer/service.go
+git commit -m "chore(indexer): standardize all log.Printf → logger.Instance with [IDX] prefix"
+```
+
+---
+
+## Task 6: End-to-end verification
+
+### Step 1: Run full test suite
+
+```bash
+go test ./... -v 2>&1 | grep -E "^(=== RUN|--- (PASS|FAIL)|FAIL|ok)" | head -60
+```
+Expected: all pass.
+
+### Step 2: Build binary
+
+```bash
+go build -o /tmp/rag-code-mcp-test ./cmd/rag-code-mcp/
+```
+
+### Step 3: Verify `state.json` no longer contains `last_percent`
+
+```bash
+cat /home/razvan/go/src/github.com/doITmagic/rag-code-mcp/.ragcode/state.json | python3 -c "import json,sys; d=json.load(sys.stdin); assert 'last_percent' not in d, 'last_percent still present!'; print('OK: last_percent removed')"
+```
+
+### Step 4: Manual log check
+
+Trigger indexing on a small workspace and verify terminal output shows:
+```
+[IDX] ws=<name> ▶ starting N languages
+[IDX] ws=<name> lang=<lang> ▶ starting
+[IDX] ws=<name> lang=<lang> ✅ DONE X files in Ys (global=Z%)
+[IDX] ws=<name> ✅ COMPLETE all N languages
+```
+
+With `MCP_LOG_LEVEL=debug`, verify per-file lines appear.
+
+### Step 5: Verify `index_status.json` has correct global_percent
+
+```bash
+cat /home/razvan/go/src/github.com/doITmagic/rag-code-mcp/.ragcode/index_status.json | python3 -m json.tool | grep global_percent
+```
+
+### Step 6: Final commit
+
+```bash
+git add -A
+git commit -m "chore: final cleanup after indexing overhaul"
+```
+
+---
+
+## Summary of files changed
+
+| File | Type |
+|---|---|
+| `pkg/indexer/state.go` | Remove `LastPercent`, `SetLastPercent` |
+| `pkg/indexer/service.go` | Remove semaphore+workers → sequential loop; `WorkspaceName` in Options |
+| `internal/service/engine/index_progress.go` | Add `GlobalPercent`, `CurrentLanguage`, `LanguagesQueued`; debounced flush |
+| `internal/service/engine/index_progress_test.go` | Tests for global_percent calculation |
+| `internal/service/engine/engine.go` | `ErrIndexingBusy`; pre-scan; search reads index_status.json; per-lang logs |

--- a/internal/service/engine/engine.go
+++ b/internal/service/engine/engine.go
@@ -783,6 +783,21 @@ func (e *Engine) IndexWorkspace(ctx context.Context, path string, recreate bool)
 	languages := parser.SupportedLanguages()
 
 	wsName := filepath.Base(wctx.Root)
+
+	// Pre-scan: count files for every language before starting indexing.
+	// This gives progressStore an accurate denominator from the start, so
+	// GlobalPercent increases monotonically instead of resetting per language.
+	var excludePatterns []string
+	if e.config != nil {
+		excludePatterns = e.config.Workspace.ExcludePatterns
+	}
+	if e.progress != nil {
+		for _, lang := range languages {
+			count := e.indexer.CountFiles(wctx.Root, lang, excludePatterns)
+			e.progress.preRegister(wctx.ID, lang, count, time.Now())
+		}
+	}
+
 	var indexErrors []string
 	for _, lang := range languages {
 		collection := wctx.CollectionName(lang)

--- a/internal/service/engine/engine.go
+++ b/internal/service/engine/engine.go
@@ -336,8 +336,8 @@ func (e *Engine) SearchCode(ctx context.Context, filePath, queryText string, lim
 	primaryColl := wctx.CollectionName(primaryLang)
 	t1 := time.Now()
 
-	// TODO(Task4): auto-resume logic — read GlobalPercent from index_status.json.
-	// If GlobalPercent is between 1-99 and state is "running", the indexer was interrupted.
+	// Auto-resume: if GlobalPercent is between 1-99 and state is "running",
+	// the indexer was interrupted — trigger a background re-index.
 	if idxStatus := loadIndexStatus(wctx.Root); idxStatus != nil {
 		if idxStatus.WorkspaceID == wctx.ID && idxStatus.GlobalPercent > 0 && idxStatus.GlobalPercent < 100 && idxStatus.State == "running" {
 			if _, ok := e.indexingJobs.Load(wctx.ID); !ok {

--- a/internal/service/engine/engine.go
+++ b/internal/service/engine/engine.go
@@ -13,9 +13,10 @@ import (
 	"time"
 
 	"github.com/doITmagic/rag-code-mcp/internal/config"
+	"github.com/doITmagic/rag-code-mcp/internal/logger"
 	"github.com/doITmagic/rag-code-mcp/internal/service/search"
-	"github.com/doITmagic/rag-code-mcp/internal/transport"
 	"github.com/doITmagic/rag-code-mcp/internal/skills"
+	"github.com/doITmagic/rag-code-mcp/internal/transport"
 	"github.com/doITmagic/rag-code-mcp/pkg/indexer"
 	"github.com/doITmagic/rag-code-mcp/pkg/parser"
 	"github.com/doITmagic/rag-code-mcp/pkg/storage"
@@ -325,9 +326,22 @@ func (e *Engine) SearchCode(ctx context.Context, filePath, queryText string, lim
 	primaryColl := wctx.CollectionName(primaryLang)
 	t1 := time.Now()
 
-	// TODO(Task4): auto-resume logic will read from index_status.json here
-
-
+	// TODO(Task4): auto-resume logic — read GlobalPercent from index_status.json.
+	// If GlobalPercent is between 1-99 and state is "running", the indexer was interrupted.
+	if idxStatus := loadIndexStatus(wctx.Root); idxStatus != nil {
+		if idxStatus.WorkspaceID == wctx.ID && idxStatus.GlobalPercent > 0 && idxStatus.GlobalPercent < 100 && idxStatus.State == "running" {
+			if _, ok := e.indexingJobs.Load(wctx.ID); !ok {
+				const resumeCooldown = 5 * time.Minute
+				now := time.Now()
+				if last, loaded := e.resumeAttempts.Load(wctx.ID); !loaded || now.Sub(last.(time.Time)) > resumeCooldown {
+					e.resumeAttempts.Store(wctx.ID, now)
+					logger.Instance.Info("[IDX] ws=%s Indexing interrupted at %d%% — auto-resuming", filepath.Base(wctx.Root), idxStatus.GlobalPercent)
+					e.StartIndexingAsync(wctx.Root, wctx.ID, nil, false)
+				}
+			}
+			logger.Instance.Info("[IDX] ws=%s Indexing in progress (%d%%) — searching available results", filepath.Base(wctx.Root), idxStatus.GlobalPercent)
+		}
+	}
 	exists, err := e.search.CollectionExists(ctx, primaryColl)
 	log.Printf("[TIMER] SearchCode collection_exists_primary=%v (cached=%v)", time.Since(t1), time.Since(t1) < time.Millisecond)
 	if err != nil {
@@ -471,8 +485,21 @@ func (e *Engine) HybridSearchCode(ctx context.Context, filePath, queryText strin
 
 	collection := wctx.CollectionName(lang)
 
-	// TODO(Task4): auto-resume logic will read from index_status.json here
-
+	// Auto-resume from index_status.json (Task4): if indexing was interrupted, resume it.
+	if idxStatus := loadIndexStatus(wctx.Root); idxStatus != nil {
+		if idxStatus.WorkspaceID == wctx.ID && idxStatus.GlobalPercent > 0 && idxStatus.GlobalPercent < 100 && idxStatus.State == "running" {
+			if _, ok := e.indexingJobs.Load(wctx.ID); !ok {
+				const resumeCooldown = 5 * time.Minute
+				now := time.Now()
+				if last, loaded := e.resumeAttempts.Load(wctx.ID); !loaded || now.Sub(last.(time.Time)) > resumeCooldown {
+					e.resumeAttempts.Store(wctx.ID, now)
+					logger.Instance.Info("[IDX] ws=%s Indexing interrupted at %d%% — auto-resuming", filepath.Base(wctx.Root), idxStatus.GlobalPercent)
+					e.StartIndexingAsync(wctx.Root, wctx.ID, nil, false)
+				}
+			}
+			logger.Instance.Info("[IDX] ws=%s Indexing in progress (%d%%) — searching available results", filepath.Base(wctx.Root), idxStatus.GlobalPercent)
+		}
+	}
 
 	exists, err := e.search.CollectionExists(ctx, collection)
 	if err != nil {
@@ -734,11 +761,10 @@ func (e *Engine) IndexWorkspace(ctx context.Context, path string, recreate bool)
 		}
 	}
 
-
-
 	// We'll iterate all supported languages.
 	languages := parser.SupportedLanguages()
 
+	wsName := filepath.Base(wctx.Root)
 	var indexErrors []string
 	for _, lang := range languages {
 		collection := wctx.CollectionName(lang)
@@ -747,19 +773,21 @@ func (e *Engine) IndexWorkspace(ctx context.Context, path string, recreate bool)
 				e.progress.update(wctx.ID, lang, doneFiles, totalFiles, time.Now())
 			}
 		}
+		logger.Instance.Info("[IDX] ws=%s lang=%s ▶ starting", wsName, lang)
 		err := e.indexer.IndexWorkspace(ctx, wctx.Root, collection, indexer.Options{
 			Language:        lang,
+			WorkspaceName:   wsName,
 			ExcludePatterns: e.config.Workspace.ExcludePatterns,
 			Recreate:        recreate,
 			Progress:        progressCb,
 		})
 		if err != nil {
-			log.Printf("[ERROR] Indexing failed for %s: %v", lang, err)
+			logger.Instance.Error("[IDX] ws=%s lang=%s ❌ failed: %v", wsName, lang, err)
 			indexErrors = append(indexErrors, fmt.Sprintf("%s: %v", lang, err))
+		} else {
+			logger.Instance.Info("[IDX] ws=%s lang=%s ✓ done", wsName, lang)
 		}
 	}
-
-
 
 	if e.watchers != nil {
 		if err := e.watchers.Start(wctx.Root, e.handleWatchChange); err != nil {

--- a/internal/service/engine/engine.go
+++ b/internal/service/engine/engine.go
@@ -791,10 +791,14 @@ func (e *Engine) IndexWorkspace(ctx context.Context, path string, recreate bool)
 	if e.config != nil {
 		excludePatterns = e.config.Workspace.ExcludePatterns
 	}
+	// Pre-scan: single WalkDir counting files per language before indexing begins.
+	// This gives progressStore an accurate denominator from the start, so
+	// GlobalPercent increases monotonically. One combined walk avoids
+	// O(languages x files) traversals that per-language scans would incur.
 	if e.progress != nil {
+		fileCounts := e.indexer.CountAllFiles(wctx.Root, excludePatterns)
 		for _, lang := range languages {
-			count := e.indexer.CountFiles(wctx.Root, lang, excludePatterns)
-			e.progress.preRegister(wctx.ID, lang, count, time.Now())
+			e.progress.preRegister(wctx.ID, lang, fileCounts[lang], time.Now())
 		}
 	}
 

--- a/internal/service/engine/engine.go
+++ b/internal/service/engine/engine.go
@@ -325,24 +325,8 @@ func (e *Engine) SearchCode(ctx context.Context, filePath, queryText string, lim
 	primaryColl := wctx.CollectionName(primaryLang)
 	t1 := time.Now()
 
-	indexerStatePath := filepath.Join(wctx.Root, ".ragcode", "state.json")
-	if idxState, sErr := indexer.LoadState(indexerStatePath); sErr == nil {
-		if idxState.LastPercent > 0 && idxState.LastPercent < 100 {
-			if _, ok := e.indexingJobs.Load(wctx.ID); !ok {
-				// Throttle auto-resume: only once per 5 minutes per workspace to avoid
-				// CPU/log churn when indexing keeps failing (e.g. Ollama is down).
-				const resumeCooldown = 5 * time.Minute
-				now := time.Now()
-				if last, loaded := e.resumeAttempts.Load(wctx.ID); !loaded || now.Sub(last.(time.Time)) > resumeCooldown {
-					e.resumeAttempts.Store(wctx.ID, now)
-					log.Printf("[INFO] Detectată indexare întreruptă (rămasă la %d%%). Se reia automat...", idxState.LastPercent)
-					e.StartIndexingAsync(wctx.Root, wctx.ID, nil, false)
-				}
-			}
-			// În ambele cazuri continuăm — Qdrant are deja date parțiale, iar progresul este adăugat în răspuns la nivelul MCP tool-ului
-			log.Printf("[INFO] Indexing in progress (%d%%) — searching available results in Qdrant", idxState.LastPercent)
-		}
-	}
+	// TODO(Task4): auto-resume logic will read from index_status.json here
+
 
 	exists, err := e.search.CollectionExists(ctx, primaryColl)
 	log.Printf("[TIMER] SearchCode collection_exists_primary=%v (cached=%v)", time.Since(t1), time.Since(t1) < time.Millisecond)
@@ -487,24 +471,8 @@ func (e *Engine) HybridSearchCode(ctx context.Context, filePath, queryText strin
 
 	collection := wctx.CollectionName(lang)
 
-	indexerStatePath := filepath.Join(wctx.Root, ".ragcode", "state.json")
-	if idxState, sErr := indexer.LoadState(indexerStatePath); sErr == nil {
-		if idxState.LastPercent > 0 && idxState.LastPercent < 100 {
-			if _, ok := e.indexingJobs.Load(wctx.ID); !ok {
-				// Throttle auto-resume: only once per 5 minutes per workspace to avoid
-				// CPU/log churn when indexing keeps failing (e.g. Ollama is down).
-				const resumeCooldown = 5 * time.Minute
-				now := time.Now()
-				if last, loaded := e.resumeAttempts.Load(wctx.ID); !loaded || now.Sub(last.(time.Time)) > resumeCooldown {
-					e.resumeAttempts.Store(wctx.ID, now)
-					log.Printf("[INFO] Detectată indexare întreruptă (rămasă la %d%%). Se reia automat...", idxState.LastPercent)
-					e.StartIndexingAsync(wctx.Root, wctx.ID, nil, false)
-				}
-			}
-			// În ambele cazuri continuăm — Qdrant are deja date parțiale, iar progresul este adăugat în răspuns la nivelul MCP tool-ului
-			log.Printf("[INFO] Indexing in progress (%d%%) — searching available results in Qdrant", idxState.LastPercent)
-		}
-	}
+	// TODO(Task4): auto-resume logic will read from index_status.json here
+
 
 	exists, err := e.search.CollectionExists(ctx, collection)
 	if err != nil {
@@ -766,11 +734,7 @@ func (e *Engine) IndexWorkspace(ctx context.Context, path string, recreate bool)
 		}
 	}
 
-	statePath := filepath.Join(wctx.Root, ".ragcode", "state.json")
-	if state, err := indexer.LoadState(statePath); err == nil {
-		state.SetLastPercent(1) // Marker for "indexer is globally running"
-		_ = state.Save(statePath)
-	}
+
 
 	// We'll iterate all supported languages.
 	languages := parser.SupportedLanguages()
@@ -795,10 +759,7 @@ func (e *Engine) IndexWorkspace(ctx context.Context, path string, recreate bool)
 		}
 	}
 
-	if state, err := indexer.LoadState(statePath); err == nil {
-		state.SetLastPercent(100)
-		_ = state.Save(statePath)
-	}
+
 
 	if e.watchers != nil {
 		if err := e.watchers.Start(wctx.Root, e.handleWatchChange); err != nil {

--- a/internal/service/engine/engine.go
+++ b/internal/service/engine/engine.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -314,7 +313,7 @@ func (e *Engine) SearchCode(ctx context.Context, filePath, queryText string, lim
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("[TIMER] SearchCode detect_context=%v", time.Since(t0))
+	logger.Instance.Debug("[TIMER] SearchCode detect_context=%v", time.Since(t0))
 
 	// Primary language from file extension
 	primaryLang := "go"
@@ -343,7 +342,7 @@ func (e *Engine) SearchCode(ctx context.Context, filePath, queryText string, lim
 		}
 	}
 	exists, err := e.search.CollectionExists(ctx, primaryColl)
-	log.Printf("[TIMER] SearchCode collection_exists_primary=%v (cached=%v)", time.Since(t1), time.Since(t1) < time.Millisecond)
+	logger.Instance.Debug("[TIMER] SearchCode collection_exists_primary=%v (cached=%v)", time.Since(t1), time.Since(t1) < time.Millisecond)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check collection: %w", err)
 	}
@@ -356,20 +355,20 @@ func (e *Engine) SearchCode(ctx context.Context, filePath, queryText string, lim
 	}
 
 	if wctx.ReindexRequired {
-		log.Printf("[INFO] Git state change detected (Head: %s), triggering background re-indexing for %s", wctx.HeadSHA, wctx.Root)
+		logger.Instance.Info("[IDX] Git state change detected (Head: %s), triggering background re-indexing for %s", wctx.HeadSHA, wctx.Root)
 		e.StartIndexingAsync(wctx.Root, wctx.ID, nil, false)
 	}
 
 	// Embed ONCE, fan-out to all language collections in parallel
 	langs := parser.SupportedLanguages()
 	if len(langs) == 0 {
-		log.Printf("[WARN] No parsers registered — SupportedLanguages() returned empty. Skipping fan-out.")
+		logger.Instance.Warn("[IDX] No parsers registered — SupportedLanguages() returned empty. Skipping fan-out.")
 		return nil, fmt.Errorf("no language parsers registered")
 	}
 
 	t2 := time.Now()
 	vector, err := e.search.EmbedQuery(ctx, queryText)
-	log.Printf("[TIMER] SearchCode embed=%v", time.Since(t2))
+	logger.Instance.Debug("[TIMER] SearchCode embed=%v", time.Since(t2))
 	if err != nil {
 		return nil, fmt.Errorf("embedding failed: %w", err)
 	}
@@ -405,7 +404,7 @@ func (e *Engine) SearchCode(ctx context.Context, filePath, queryText string, lim
 			}
 			elapsed := time.Since(gt)
 			if sErr != nil {
-				log.Printf("[WARN] SearchCode: fan-out failed for %s: %v", c, sErr)
+				logger.Instance.Warn("[IDX] SearchCode: fan-out failed for %s: %v", c, sErr)
 				resultsChan <- langResult{lang: l, coll: c, err: sErr, elapsed: elapsed}
 				return
 			}
@@ -417,7 +416,7 @@ func (e *Engine) SearchCode(ctx context.Context, filePath, queryText string, lim
 
 	wg.Wait()
 	close(resultsChan)
-	log.Printf("[TIMER] SearchCode fanout_total=%v (langs=%d)", time.Since(t3), len(langs))
+	logger.Instance.Debug("[TIMER] SearchCode fanout_total=%v (langs=%d)", time.Since(t3), len(langs))
 
 	// Merge: primary lang results first, others appended; surface first error if no results
 	var primaryResults []storage.SearchResult
@@ -428,13 +427,13 @@ func (e *Engine) SearchCode(ctx context.Context, filePath, queryText string, lim
 
 	for lr := range resultsChan {
 		if lr.err != nil {
-			log.Printf("[TIMER] SearchCode lang=%s err elapsed=%v", lr.lang, lr.elapsed)
+			logger.Instance.Debug("[TIMER] SearchCode lang=%s err elapsed=%v", lr.lang, lr.elapsed)
 			if firstErr == nil {
 				firstErr = lr.err
 			}
 			continue
 		}
-		log.Printf("[TIMER] SearchCode lang=%s hits=%d elapsed=%v", lr.lang, len(lr.results), lr.elapsed)
+		logger.Instance.Debug("[TIMER] SearchCode lang=%s hits=%d elapsed=%v", lr.lang, len(lr.results), lr.elapsed)
 		if lr.coll == primaryColl {
 			primaryResults = lr.results
 		} else {
@@ -456,7 +455,7 @@ func (e *Engine) SearchCode(ctx context.Context, filePath, queryText string, lim
 		return nil, fmt.Errorf("search failed: %w", firstErr)
 	}
 
-	log.Printf("[TIMER] SearchCode TOTAL=%v (detect=%v embed=%v fanout=%v)",
+	logger.Instance.Debug("[TIMER] SearchCode TOTAL=%v (detect=%v embed=%v fanout=%v)",
 		time.Since(t0), t1.Sub(t0), t2.Sub(t1), time.Since(t3))
 
 	return &SearchCodeResult{
@@ -515,7 +514,7 @@ func (e *Engine) HybridSearchCode(ctx context.Context, filePath, queryText strin
 	}
 
 	if wctx.ReindexRequired {
-		log.Printf("[INFO] Git state change detected, triggering background re-indexing...")
+		logger.Instance.Info("[IDX] Git state change detected, triggering background re-indexing for ws=%s", filepath.Base(wctx.Root))
 		e.StartIndexingAsync(wctx.Root, wctx.ID, nil, false)
 	}
 
@@ -544,7 +543,7 @@ func (e *Engine) HybridSearchCode(ctx context.Context, filePath, queryText strin
 func (e *Engine) ExactSearchPolyglot(ctx context.Context, wsID string, filters map[string]interface{}, limit int) ([]storage.SearchResult, error) {
 	langs := parser.SupportedLanguages()
 	if len(langs) == 0 {
-		log.Printf("[WARN] No parsers registered — SupportedLanguages() returned empty. Skipping ExactSearch.")
+		logger.Instance.Warn("[IDX] No parsers registered — SupportedLanguages() returned empty. Skipping ExactSearch.")
 		return nil, &ErrNoCollectionsFound{WorkspaceID: wsID}
 	}
 
@@ -564,7 +563,7 @@ func (e *Engine) ExactSearchPolyglot(ctx context.Context, wsID string, filters m
 
 			exists, err := e.search.CollectionExists(ctx, coll)
 			if err != nil {
-				log.Printf("[WARN] ExactSearchPolyglot: cannot check collection %s: %v", coll, err)
+				logger.Instance.Warn("[IDX] ExactSearchPolyglot: cannot check collection %s: %v", coll, err)
 				return
 			}
 			if !exists {
@@ -574,7 +573,7 @@ func (e *Engine) ExactSearchPolyglot(ctx context.Context, wsID string, filters m
 
 			res, sErr := e.search.ExactSearch(ctx, coll, filters, limit)
 			if sErr != nil {
-				log.Printf("[WARN] ExactSearchPolyglot: search failed for %s: %v", coll, sErr)
+				logger.Instance.Warn("[IDX] ExactSearchPolyglot: search failed for %s: %v", coll, sErr)
 				return
 			}
 			resultsChan <- trial{results: res}
@@ -655,7 +654,7 @@ func (e *Engine) popPendingIndex(workspaceID string) (files []string, overflow b
 func (e *Engine) tryStartPendingIndex(root, workspaceID string) {
 	files, overflow := e.popPendingIndex(workspaceID)
 	if overflow {
-		log.Printf("[INFO] ♻️ Pending changes exceeded limit for %s - triggering full scan incremental indexing", root)
+		logger.Instance.Info("[IDX] ♻️ Pending changes exceeded limit for ws=%s — triggering full scan", filepath.Base(root))
 		e.StartIndexingAsync(root, workspaceID, nil, false)
 		return
 	}
@@ -688,20 +687,20 @@ func (e *Engine) StartIndexingAsync(root, id string, changedFiles []string, recr
 		var err error
 
 		if len(changedFiles) > 0 {
-			log.Printf("[INFO] ♻️ Starting incremental indexing for %d files in: %s", len(changedFiles), root)
+			logger.Instance.Info("[IDX] ♻️ ws=%s Starting incremental indexing for %d files", filepath.Base(root), len(changedFiles))
 			err = e.IndexFiles(ctx, root, changedFiles)
 		} else {
-			log.Printf("[INFO] 🚀 Starting background indexing for: %s (recreate=%v)", root, recreate)
+			logger.Instance.Info("[IDX] 🚀 ws=%s Starting background indexing (recreate=%v)", filepath.Base(root), recreate)
 			err = e.IndexWorkspace(ctx, root, recreate)
 		}
 
 		if err != nil {
-			log.Printf("[ERROR] Background indexing failed for %s: %v", root, err)
+			logger.Instance.Error("[IDX] ws=%s Background indexing failed: %v", filepath.Base(root), err)
 			if e.progress != nil {
 				e.progress.fail(id, root, time.Now(), err.Error())
 			}
 		} else {
-			log.Printf("[INFO] ✅ Background indexing completed for: %s", root)
+			logger.Instance.Info("[IDX] ✅ ws=%s Background indexing completed", filepath.Base(root))
 			if e.progress != nil {
 				e.progress.complete(id, root, time.Now())
 			}
@@ -734,7 +733,7 @@ func (e *Engine) IndexFiles(ctx context.Context, root string, files []string) er
 
 	for _, p := range files {
 		if _, indexErr := e.indexer.IndexFile(ctx, collection, p, state); indexErr != nil {
-			log.Printf("[ERROR] Failed to index %s: %v", p, indexErr)
+			logger.Instance.Warn("[IDX] Failed to index %s: %v", filepath.Base(p), indexErr)
 		}
 	}
 
@@ -756,7 +755,7 @@ func (e *Engine) IndexWorkspace(ctx context.Context, path string, recreate bool)
 	if e.config != nil && e.config.Workspace.AutoInstallSSESkill {
 		if !skills.IsSkillInstalled("ragcode-sse", wctx.Root) {
 			if err := skills.InstallSkill("ragcode-sse", wctx.Root, "agent", e.config.Skills); err != nil {
-				log.Printf("[WARN] Failed to install ragcode-sse skill for %s: %v", wctx.Root, err)
+				logger.Instance.Warn("[IDX] Failed to install ragcode-sse skill for ws=%s: %v", wctx.Root, err)
 			}
 		}
 	}
@@ -791,7 +790,7 @@ func (e *Engine) IndexWorkspace(ctx context.Context, path string, recreate bool)
 
 	if e.watchers != nil {
 		if err := e.watchers.Start(wctx.Root, e.handleWatchChange); err != nil {
-			log.Printf("[WARN] Failed to start watcher for %s: %v", wctx.Root, err)
+			logger.Instance.Warn("[IDX] Failed to start watcher for ws=%s: %v", filepath.Base(wctx.Root), err)
 		}
 	}
 

--- a/internal/service/engine/engine.go
+++ b/internal/service/engine/engine.go
@@ -127,6 +127,17 @@ func (e *Engine) GetIndexProgress(workspaceID, workspaceRoot string) *IndexProgr
 	return e.progress.get(workspaceID, workspaceRoot)
 }
 
+// ActiveIndexingJobs returns the IDs of workspaces currently being indexed.
+// Useful for health checks and debugging concurrent indexing scenarios.
+func (e *Engine) ActiveIndexingJobs() []string {
+	var ids []string
+	e.indexingJobs.Range(func(k, _ any) bool {
+		ids = append(ids, k.(string))
+		return true
+	})
+	return ids
+}
+
 // Config returns the engine configuration.
 func (e *Engine) Config() *config.Config {
 	return e.config
@@ -669,6 +680,14 @@ func (e *Engine) tryStartPendingIndex(root, workspaceID string) {
 func (e *Engine) StartIndexingAsync(root, id string, changedFiles []string, recreate bool) {
 	if _, loaded := e.indexingJobs.LoadOrStore(id, time.Now()); loaded {
 		return // Already running
+	}
+
+	// Count active jobs after adding this one — warn if multiple workspaces are indexing
+	// simultaneously (they serialize against each other at Ollama level).
+	var activeCount int
+	e.indexingJobs.Range(func(_, _ any) bool { activeCount++; return true })
+	if activeCount > 1 {
+		logger.Instance.Warn("[IDX] ⚠️ %d workspaces indexing simultaneously — Ollama requests will serialize implicitly (ws=%s)", activeCount, filepath.Base(root))
 	}
 
 	jobID := fmt.Sprintf("%s-%d", id, time.Now().UnixNano())

--- a/internal/service/engine/engine.go
+++ b/internal/service/engine/engine.go
@@ -814,7 +814,7 @@ func (e *Engine) IndexWorkspace(ctx context.Context, path string, recreate bool)
 		err := e.indexer.IndexWorkspace(ctx, wctx.Root, collection, indexer.Options{
 			Language:        lang,
 			WorkspaceName:   wsName,
-			ExcludePatterns: e.config.Workspace.ExcludePatterns,
+			ExcludePatterns: excludePatterns,
 			Recreate:        recreate,
 			Progress:        progressCb,
 		})

--- a/internal/service/engine/engine_searchcode_test.go
+++ b/internal/service/engine/engine_searchcode_test.go
@@ -371,14 +371,24 @@ func TestSearchCodeAutoResumesInterruptedIndexing(t *testing.T) {
 		t.Error("cooldown violated: auto-resume was triggered again within the 5-minute window")
 	}
 
-	// Wait for the background indexing goroutine to finish writing to wsRoot/.ragcode/
-	// before the test returns. Without this, t.TempDir() cleanup races with the goroutine
-	// and fails with "directory not empty".
+	// Stop the progress flusher goroutine before the test returns.
+	// Without this the goroutine can still write to wsRoot/.ragcode/ while
+	// t.TempDir() cleanup removes the directory, triggering a race under -race.
+	t.Cleanup(func() {
+		if eng.progress != nil {
+			eng.progress.stop()
+		}
+	})
+
+	// Wait for the background indexing goroutine to drain before test returns.
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		if len(eng.ActiveIndexingJobs()) == 0 {
 			break
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+	if jobs := eng.ActiveIndexingJobs(); len(jobs) != 0 {
+		t.Fatalf("background indexing jobs still active after 5s wait: %v", jobs)
 	}
 }

--- a/internal/service/engine/engine_searchcode_test.go
+++ b/internal/service/engine/engine_searchcode_test.go
@@ -276,7 +276,6 @@ func TestSearchCodeResumeInterruptedIndexing(t *testing.T) {
 
 	// Mock resolver configures a fake detector returning a tmp root
 	rootDir := t.TempDir()
-	_ = rootDir // used for workspace root context
 	eng.SetResolver(resolver.New(resolver.Dependencies{Detector: &mockDirDetector{root: rootDir}}))
 
 	// Get workspace ID early

--- a/internal/service/engine/engine_searchcode_test.go
+++ b/internal/service/engine/engine_searchcode_test.go
@@ -2,10 +2,8 @@ package engine
 
 import (
 	"context"
-	"path/filepath"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/doITmagic/rag-code-mcp/internal/config"
 	"github.com/doITmagic/rag-code-mcp/internal/service/search"
@@ -278,6 +276,7 @@ func TestSearchCodeResumeInterruptedIndexing(t *testing.T) {
 
 	// Mock resolver configures a fake detector returning a tmp root
 	rootDir := t.TempDir()
+	_ = rootDir // used for workspace root context
 	eng.SetResolver(resolver.New(resolver.Dependencies{Detector: &mockDirDetector{root: rootDir}}))
 
 	// Get workspace ID early
@@ -294,30 +293,13 @@ func TestSearchCodeResumeInterruptedIndexing(t *testing.T) {
 	}
 	eng.SetSearchService(search.NewService(llmProvider, store))
 
-	// Creăm state.json cu LastPercent = 55%
-	state := indexer.NewState()
-	state.SetLastPercent(55)
-	statePath := filepath.Join(rootDir, ".ragcode", "state.json")
-	if err := state.Save(statePath); err != nil {
-		t.Fatalf("Failed to save fake state.json: %v", err)
-	}
-
-	// Cu noua logică: search-ul NU mai blochează când LastPercent e între 1-99.
-	// Indexarea întreruptă e reluată automat în background, iar search-ul continuă în Qdrant.
+	// NOTE: LastPercent removed from state.json — progress now tracked in index_status.json.
+	// Auto-resume via index_status.json will be tested in Task 4.
+	// This test verifies SearchCode succeeds when collection exists.
 	_, err := eng.SearchCode(context.Background(), "dummy.go", "test", 10, false)
 	if err != nil {
-		t.Fatalf("Expected no error, search should continue, got: %v", err)
+		t.Fatalf("Expected no error when collection exists, got: %v", err)
 	}
-
-	// Așteptăm ca job-ul din background să se termine și să iasă din indexingJobs.
-	// (Previne eroarea de t.TempDir() "directory not empty"). Limităm la max 5 secunde.
-	for i := 0; i < 100; i++ {
-		if _, ok := eng.indexingJobs.Load(wctx.ID); !ok {
-			return // Success: job started and cleanly finished
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	t.Errorf("Expected background indexing to finish within 5s, but job is still active")
 }
 
 // mockDirDetector is like mockDetector but allows specifying the root dir

--- a/internal/service/engine/engine_searchcode_test.go
+++ b/internal/service/engine/engine_searchcode_test.go
@@ -293,9 +293,8 @@ func TestSearchCodeResumeInterruptedIndexing(t *testing.T) {
 	}
 	eng.SetSearchService(search.NewService(llmProvider, store))
 
-	// NOTE: LastPercent removed from state.json — progress now tracked in index_status.json.
-	// Auto-resume via index_status.json will be tested in Task 4.
-	// This test verifies SearchCode succeeds when collection exists.
+	// Verify SearchCode succeeds (returns results) when collection exists.
+	// Auto-resume behavior is tested separately in TestSearchCodeAutoResumesInterruptedIndexing.
 	_, err := eng.SearchCode(context.Background(), "dummy.go", "test", 10, false)
 	if err != nil {
 		t.Fatalf("Expected no error when collection exists, got: %v", err)

--- a/internal/service/engine/engine_searchcode_test.go
+++ b/internal/service/engine/engine_searchcode_test.go
@@ -371,4 +371,15 @@ func TestSearchCodeAutoResumesInterruptedIndexing(t *testing.T) {
 	if first.(time.Time) != second.(time.Time) {
 		t.Error("cooldown violated: auto-resume was triggered again within the 5-minute window")
 	}
+
+	// Wait for the background indexing goroutine to finish writing to wsRoot/.ragcode/
+	// before the test returns. Without this, t.TempDir() cleanup races with the goroutine
+	// and fails with "directory not empty".
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(eng.ActiveIndexingJobs()) == 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }

--- a/internal/service/engine/engine_searchcode_test.go
+++ b/internal/service/engine/engine_searchcode_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/doITmagic/rag-code-mcp/internal/config"
 	"github.com/doITmagic/rag-code-mcp/internal/service/search"
@@ -311,4 +312,63 @@ func (m *mockDirDetector) DetectFromFilePath(_ context.Context, path string) (*c
 		Root:       m.root,
 		Confidence: 1.0,
 	}, nil
+}
+
+// TestSearchCodeAutoResumesInterruptedIndexing verifies that SearchCode triggers
+// a background re-index when index_status.json shows an interrupted indexing
+// session (state="running", 1 <= GlobalPercent <= 99).
+// It also verifies the 5-minute cooldown prevents repeated resume triggers.
+func TestSearchCodeAutoResumesInterruptedIndexing(t *testing.T) {
+	llmProvider := &countingLLM{}
+	eng := newEngineCountingLLM(&testStore{existing: map[string]bool{}}, llmProvider)
+
+	wsRoot := t.TempDir()
+	eng.SetResolver(resolver.New(resolver.Dependencies{Detector: &mockDirDetector{root: wsRoot}}))
+
+	// Detect context to learn the workspace ID (needed for index_status.json)
+	wctx, err := eng.DetectContext(context.Background(), "dummy.go")
+	if err != nil || wctx == nil {
+		t.Fatal("Failed to detect workspace context")
+	}
+
+	// Write index_status.json that simulates an interrupted indexing session at 50%
+	now := time.Now()
+	status := IndexProgress{
+		JobID:         "interrupted-test-job",
+		WorkspaceID:   wctx.ID,
+		WorkspaceRoot: wsRoot,
+		State:         "running",
+		GlobalPercent: 50,
+		StartedAt:     now.Add(-10 * time.Minute),
+		UpdatedAt:     now,
+		Languages:     map[string]IndexLanguageProgress{},
+	}
+	saveIndexStatus(wsRoot, &status)
+
+	// Make the go collection exist so SearchCode gets past the fast-fail check
+	goColl := CollectionNameFor(wctx.ID, "go")
+	store := &multiLangStore{
+		testStore: testStore{
+			existing: map[string]bool{goColl: true},
+		},
+	}
+	eng.SetSearchService(search.NewService(llmProvider, store))
+
+	// First call — auto-resume should fire
+	_, _ = eng.SearchCode(context.Background(), "dummy.go", "test", 10, false)
+
+	// resumeAttempts is updated synchronously before the goroutine starts,
+	// so it is readable immediately after SearchCode returns.
+	if _, ok := eng.resumeAttempts.Load(wctx.ID); !ok {
+		t.Error("expected auto-resume to be triggered: resumeAttempts has no entry for workspace")
+	}
+
+	// Second call within cooldown — should NOT trigger another resume attempt.
+	// We verify this by checking that resumeAttempts still holds the same timestamp.
+	first, _ := eng.resumeAttempts.Load(wctx.ID)
+	_, _ = eng.SearchCode(context.Background(), "dummy.go", "test", 10, false)
+	second, _ := eng.resumeAttempts.Load(wctx.ID)
+	if first.(time.Time) != second.(time.Time) {
+		t.Error("cooldown violated: auto-resume was triggered again within the 5-minute window")
+	}
 }

--- a/internal/service/engine/index_progress.go
+++ b/internal/service/engine/index_progress.go
@@ -122,10 +122,10 @@ func (s *progressStore) triggerFlush() {
 // It is a no-op if the workspace job has not been started yet.
 func (s *progressStore) preRegister(workspaceID, lang string, totalFiles int, now time.Time) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	p, ok := s.jobs[workspaceID]
 	if !ok {
+		s.mu.Unlock()
 		return
 	}
 	if p.Languages == nil {
@@ -141,6 +141,9 @@ func (s *progressStore) preRegister(workspaceID, lang string, totalFiles int, no
 		p.GlobalPercent = calcGlobalPercent(p.Languages)
 	}
 	p.UpdatedAt = now
+	s.mu.Unlock()
+	// Flush so the updated totals are persisted promptly.
+	s.triggerFlush()
 }
 
 func (s *progressStore) get(workspaceID string, workspaceRoot string) *IndexProgress {
@@ -190,7 +193,6 @@ func (s *progressStore) get(workspaceID string, workspaceRoot string) *IndexProg
 
 func (s *progressStore) start(workspaceID, workspaceRoot, jobID string, now time.Time) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.jobs[workspaceID] = &IndexProgress{
 		JobID:         jobID,
 		WorkspaceID:   workspaceID,
@@ -200,6 +202,10 @@ func (s *progressStore) start(workspaceID, workspaceRoot, jobID string, now time
 		UpdatedAt:     now,
 		Languages:     map[string]IndexLanguageProgress{},
 	}
+	s.mu.Unlock()
+	// Flush immediately so index_status.json exists from the moment indexing starts.
+	// Without this, a crash before the first update() would leave no status file.
+	s.triggerFlush()
 }
 
 func (s *progressStore) update(workspaceID, lang string, done, total int, now time.Time) {

--- a/internal/service/engine/index_progress.go
+++ b/internal/service/engine/index_progress.go
@@ -23,17 +23,20 @@ type IndexProgress struct {
 	JobID           string                           `json:"job_id"`
 	WorkspaceID     string                           `json:"workspace_id"`
 	WorkspaceRoot   string                           `json:"workspace_root"`
-	State           string                           `json:"state"` // starting|running|completed|failed
-	GlobalPercent   int                              `json:"global_percent"`  // weighted across all languages
+	State           string                           `json:"state"`            // starting|running|completed|failed
+	GlobalPercent   int                              `json:"global_percent"`   // weighted across all languages
 	CurrentLanguage string                           `json:"current_language"` // language currently being indexed
 	StartedAt       time.Time                        `json:"started_at"`
 	CompletedAt     *time.Time                       `json:"completed_at,omitempty"`
-	Languages       map[string]IndexLanguageProgress  `json:"languages,omitempty"`
+	Languages       map[string]IndexLanguageProgress `json:"languages,omitempty"`
 	UpdatedAt       time.Time                        `json:"updated_at"`
 	Error           string                           `json:"error,omitempty"`
 }
 
-// calcGlobalPercent computes GlobalPercent as sum(done) / sum(total) * 100.
+// calcGlobalPercent computes GlobalPercent as sum(done) / sum(total) * 100
+// across all languages. Languages are pre-registered with accurate TotalFiles
+// before indexing begins (via preRegister), so this sum is monotonically
+// non-decreasing.
 // Must be called with s.mu held.
 func calcGlobalPercent(langs map[string]IndexLanguageProgress) int {
 	var totalDone, totalFiles int
@@ -67,6 +70,8 @@ func newProgressStore() *progressStore {
 }
 
 // runFlusher drains flushCh and persists all jobs debounced at 500ms.
+// It snapshots job data under the mutex (fast), then writes to disk outside
+// the lock so that update()/get() are not blocked during disk I/O.
 func (s *progressStore) runFlusher() {
 	for range s.flushCh {
 		time.Sleep(500 * time.Millisecond)
@@ -74,24 +79,32 @@ func (s *progressStore) runFlusher() {
 		for len(s.flushCh) > 0 {
 			<-s.flushCh
 		}
+		// Snapshot under the lock (fast copy), then release before disk I/O.
 		s.mu.Lock()
+		snapshots := make([]IndexProgress, 0, len(s.jobs))
 		for _, p := range s.jobs {
-			if p.WorkspaceRoot != "" {
-				cp := *p
-				if p.Languages != nil {
-					cp.Languages = make(map[string]IndexLanguageProgress, len(p.Languages))
-					for k, v := range p.Languages {
-						cp.Languages[k] = v
-					}
-				}
-				if p.CompletedAt != nil {
-					t := *p.CompletedAt
-					cp.CompletedAt = &t
-				}
-				saveIndexStatus(p.WorkspaceRoot, &cp)
+			if p.WorkspaceRoot == "" {
+				continue
 			}
+			cp := *p
+			if p.Languages != nil {
+				cp.Languages = make(map[string]IndexLanguageProgress, len(p.Languages))
+				for k, v := range p.Languages {
+					cp.Languages[k] = v
+				}
+			}
+			if p.CompletedAt != nil {
+				t := *p.CompletedAt
+				cp.CompletedAt = &t
+			}
+			snapshots = append(snapshots, cp)
 		}
 		s.mu.Unlock()
+		// Write snapshots to disk without holding the lock.
+		for i := range snapshots {
+			cp := snapshots[i]
+			saveIndexStatus(cp.WorkspaceRoot, &cp)
+		}
 	}
 }
 
@@ -101,6 +114,33 @@ func (s *progressStore) triggerFlush() {
 	case s.flushCh <- struct{}{}:
 	default: // already pending — no need to queue another
 	}
+}
+
+// preRegister sets the expected TotalFiles for a language before indexing begins.
+// This ensures calcGlobalPercent has an accurate denominator from the start,
+// making GlobalPercent monotonically non-decreasing throughout indexing.
+// It is a no-op if the workspace job has not been started yet.
+func (s *progressStore) preRegister(workspaceID, lang string, totalFiles int, now time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	p, ok := s.jobs[workspaceID]
+	if !ok {
+		return
+	}
+	if p.Languages == nil {
+		p.Languages = make(map[string]IndexLanguageProgress)
+	}
+	// Only pre-register if the language hasn't started processing yet.
+	if _, exists := p.Languages[lang]; !exists {
+		p.Languages[lang] = IndexLanguageProgress{
+			TotalFiles: totalFiles,
+			DoneFiles:  0,
+			Percent:    0,
+		}
+		p.GlobalPercent = calcGlobalPercent(p.Languages)
+	}
+	p.UpdatedAt = now
 }
 
 func (s *progressStore) get(workspaceID string, workspaceRoot string) *IndexProgress {

--- a/internal/service/engine/index_progress.go
+++ b/internal/service/engine/index_progress.go
@@ -58,24 +58,50 @@ type progressStore struct {
 	mu      sync.Mutex
 	jobs    map[string]*IndexProgress
 	flushCh chan struct{} // debounced disk flush signal
+	done    chan struct{} // closed by stop() to shut down runFlusher
 }
 
 func newProgressStore() *progressStore {
 	ps := &progressStore{
 		jobs:    map[string]*IndexProgress{},
 		flushCh: make(chan struct{}, 1),
+		done:    make(chan struct{}),
 	}
 	go ps.runFlusher()
 	return ps
 }
 
+// stop shuts down the background flusher goroutine. Must be called when the
+// progressStore is no longer needed (e.g. in test cleanup or Engine.Close).
+func (s *progressStore) stop() {
+	select {
+	case <-s.done:
+		// already stopped
+	default:
+		close(s.done)
+	}
+}
+
 // runFlusher drains flushCh and persists all jobs debounced at 500ms.
 // It snapshots job data under the mutex (fast), then writes to disk outside
 // the lock so that update()/get() are not blocked during disk I/O.
+// It exits when stop() is called (done channel is closed).
 func (s *progressStore) runFlusher() {
-	for range s.flushCh {
-		time.Sleep(500 * time.Millisecond)
-		// Drain any extra signals accumulated during the sleep.
+	for {
+		select {
+		case <-s.done:
+			return
+		case _, ok := <-s.flushCh:
+			if !ok {
+				return
+			}
+		}
+		// Debounce: wait 500ms then drain any extra signals.
+		select {
+		case <-s.done:
+			return
+		case <-time.After(500 * time.Millisecond):
+		}
 		for len(s.flushCh) > 0 {
 			<-s.flushCh
 		}

--- a/internal/service/engine/index_progress.go
+++ b/internal/service/engine/index_progress.go
@@ -20,24 +20,87 @@ type IndexLanguageProgress struct {
 }
 
 type IndexProgress struct {
-	JobID         string                           `json:"job_id"`
-	WorkspaceID   string                           `json:"workspace_id"`
-	WorkspaceRoot string                           `json:"workspace_root"`
-	State         string                           `json:"state"` // starting|running|completed|failed
-	StartedAt     time.Time                        `json:"started_at"`
-	CompletedAt   *time.Time                       `json:"completed_at,omitempty"`
-	Languages     map[string]IndexLanguageProgress `json:"languages,omitempty"`
-	UpdatedAt     time.Time                        `json:"updated_at"`
-	Error         string                           `json:"error,omitempty"`
+	JobID           string                           `json:"job_id"`
+	WorkspaceID     string                           `json:"workspace_id"`
+	WorkspaceRoot   string                           `json:"workspace_root"`
+	State           string                           `json:"state"` // starting|running|completed|failed
+	GlobalPercent   int                              `json:"global_percent"`  // weighted across all languages
+	CurrentLanguage string                           `json:"current_language"` // language currently being indexed
+	StartedAt       time.Time                        `json:"started_at"`
+	CompletedAt     *time.Time                       `json:"completed_at,omitempty"`
+	Languages       map[string]IndexLanguageProgress  `json:"languages,omitempty"`
+	UpdatedAt       time.Time                        `json:"updated_at"`
+	Error           string                           `json:"error,omitempty"`
+}
+
+// calcGlobalPercent computes GlobalPercent as sum(done) / sum(total) * 100.
+// Must be called with s.mu held.
+func calcGlobalPercent(langs map[string]IndexLanguageProgress) int {
+	var totalDone, totalFiles int
+	for _, lp := range langs {
+		totalDone += lp.DoneFiles
+		totalFiles += lp.TotalFiles
+	}
+	if totalFiles == 0 {
+		return 0
+	}
+	pct := totalDone * 100 / totalFiles
+	if pct > 100 {
+		return 100
+	}
+	return pct
 }
 
 type progressStore struct {
-	mu   sync.Mutex
-	jobs map[string]*IndexProgress
+	mu      sync.Mutex
+	jobs    map[string]*IndexProgress
+	flushCh chan struct{} // debounced disk flush signal
 }
 
 func newProgressStore() *progressStore {
-	return &progressStore{jobs: map[string]*IndexProgress{}}
+	ps := &progressStore{
+		jobs:    map[string]*IndexProgress{},
+		flushCh: make(chan struct{}, 1),
+	}
+	go ps.runFlusher()
+	return ps
+}
+
+// runFlusher drains flushCh and persists all jobs debounced at 500ms.
+func (s *progressStore) runFlusher() {
+	for range s.flushCh {
+		time.Sleep(500 * time.Millisecond)
+		// Drain any extra signals accumulated during the sleep.
+		for len(s.flushCh) > 0 {
+			<-s.flushCh
+		}
+		s.mu.Lock()
+		for _, p := range s.jobs {
+			if p.WorkspaceRoot != "" {
+				cp := *p
+				if p.Languages != nil {
+					cp.Languages = make(map[string]IndexLanguageProgress, len(p.Languages))
+					for k, v := range p.Languages {
+						cp.Languages[k] = v
+					}
+				}
+				if p.CompletedAt != nil {
+					t := *p.CompletedAt
+					cp.CompletedAt = &t
+				}
+				saveIndexStatus(p.WorkspaceRoot, &cp)
+			}
+		}
+		s.mu.Unlock()
+	}
+}
+
+// triggerFlush signals the flusher non-blockingly.
+func (s *progressStore) triggerFlush() {
+	select {
+	case s.flushCh <- struct{}{}:
+	default: // already pending — no need to queue another
+	}
 }
 
 func (s *progressStore) get(workspaceID string, workspaceRoot string) *IndexProgress {
@@ -101,7 +164,6 @@ func (s *progressStore) start(workspaceID, workspaceRoot, jobID string, now time
 
 func (s *progressStore) update(workspaceID, lang string, done, total int, now time.Time) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	p, ok := s.jobs[workspaceID]
 	if !ok {
 		p = &IndexProgress{
@@ -132,7 +194,11 @@ func (s *progressStore) update(workspaceID, lang string, done, total int, now ti
 		Percent:    pct,
 		UpdatedAt:  now,
 	}
+	p.CurrentLanguage = lang
+	p.GlobalPercent = calcGlobalPercent(p.Languages)
 	p.UpdatedAt = now
+	s.mu.Unlock()
+	s.triggerFlush()
 }
 
 func (s *progressStore) complete(workspaceID, workspaceRoot string, now time.Time) {
@@ -143,9 +209,9 @@ func (s *progressStore) complete(workspaceID, workspaceRoot string, now time.Tim
 		return
 	}
 	p.State = "completed"
+	p.GlobalPercent = 100
 	p.UpdatedAt = now
 	p.CompletedAt = &now
-
 	cp := *p
 	if p.Languages != nil {
 		cp.Languages = make(map[string]IndexLanguageProgress, len(p.Languages))
@@ -158,8 +224,7 @@ func (s *progressStore) complete(workspaceID, workspaceRoot string, now time.Tim
 		cp.CompletedAt = &t
 	}
 	s.mu.Unlock()
-
-	// Persist to disk so index_age survives process restarts.
+	// complete() is a one-time event — write synchronously so it persists even if process exits.
 	saveIndexStatus(workspaceRoot, &cp)
 }
 
@@ -173,7 +238,6 @@ func (s *progressStore) fail(workspaceID, workspaceRoot string, now time.Time, e
 	p.State = "failed"
 	p.Error = errMsg
 	p.UpdatedAt = now
-
 	cp := *p
 	if p.Languages != nil {
 		cp.Languages = make(map[string]IndexLanguageProgress, len(p.Languages))
@@ -181,13 +245,8 @@ func (s *progressStore) fail(workspaceID, workspaceRoot string, now time.Time, e
 			cp.Languages[k] = v
 		}
 	}
-	if p.CompletedAt != nil {
-		t := *p.CompletedAt
-		cp.CompletedAt = &t
-	}
 	s.mu.Unlock()
-
-	// Persist failed state too so we know something went wrong.
+	// fail() is a one-time event — write synchronously.
 	saveIndexStatus(workspaceRoot, &cp)
 }
 

--- a/internal/service/engine/index_progress_test.go
+++ b/internal/service/engine/index_progress_test.go
@@ -67,3 +67,45 @@ func TestProgressStoreDiskRoundTrip(t *testing.T) {
 		t.Error("deep copy failed for disk-loaded branch: mutation corrupted cached entry")
 	}
 }
+
+// TestProgressStoreGlobalPercent verifies that GlobalPercent is calculated correctly
+// as sum(done_all_langs) / sum(total_all_langs) * 100.
+func TestProgressStoreGlobalPercent(t *testing.T) {
+	store := newProgressStore()
+	now := time.Now()
+
+	store.start("ws1", "/tmp/ws1", "job1", now)
+	store.update("ws1", "md", 120, 120, now)  // md: 100% (120/120)
+	store.update("ws1", "go", 234, 500, now)  // go: 46%  (234/500)
+
+	p := store.get("ws1", "")
+	if p == nil {
+		t.Fatal("expected progress, got nil")
+	}
+
+	// global = (120 + 234) / (120 + 500) * 100 = 354/620*100 = 57%
+	want := 57
+	if p.GlobalPercent != want {
+		t.Errorf("expected GlobalPercent=%d, got %d", want, p.GlobalPercent)
+	}
+}
+
+// TestProgressStoreCurrentLanguage verifies that CurrentLanguage is updated on each update().
+func TestProgressStoreCurrentLanguage(t *testing.T) {
+	store := newProgressStore()
+	now := time.Now()
+
+	store.start("ws2", "/tmp/ws2", "job2", now)
+	store.update("ws2", "md", 10, 100, now)
+
+	p := store.get("ws2", "")
+	if p.CurrentLanguage != "md" {
+		t.Errorf("expected CurrentLanguage='md', got %q", p.CurrentLanguage)
+	}
+
+	store.update("ws2", "go", 5, 200, now)
+	p = store.get("ws2", "")
+	if p.CurrentLanguage != "go" {
+		t.Errorf("expected CurrentLanguage='go', got %q", p.CurrentLanguage)
+	}
+}

--- a/internal/service/engine/index_progress_test.go
+++ b/internal/service/engine/index_progress_test.go
@@ -146,11 +146,11 @@ func TestProgressStoreTwoWorkspacesIsolated(t *testing.T) {
 		t.Errorf("wsB: expected GlobalPercent=%d, got %d", wantB, pB.GlobalPercent)
 	}
 
-	// WsA should NOT have python data from wsB and vice versa
-	if _, ok := pA.Languages["python"]; !ok {
-		// python was explicitly added to wsA with 0/200
+	// WsA should have python (was added with 0/200), wsB should not
+	if _, exists := pA.Languages["python"]; !exists {
+		t.Error("wsA should have python language entry (added with 0/200)")
 	}
-	if _, ok := pB.Languages["python"]; ok {
+	if _, exists := pB.Languages["python"]; exists {
 		t.Error("wsB should not have python language (was only set on wsA)")
 	}
 

--- a/internal/service/engine/index_progress_test.go
+++ b/internal/service/engine/index_progress_test.go
@@ -124,7 +124,7 @@ func TestProgressStoreTwoWorkspacesIsolated(t *testing.T) {
 	rootB := t.TempDir()
 
 	// WsA: go 50/100, python 0/200 → global = (50+0)/(100+200)*100 = 16%
-	// python is in the denominator because totals are pre-registered
+	// python is in the denominator because it was added via update() with 0 processed/200 total
 	store.start("wsA", rootA, "jobA", now)
 	store.update("wsA", "go", 50, 100, now)
 	store.update("wsA", "python", 0, 200, now)

--- a/internal/service/engine/index_progress_test.go
+++ b/internal/service/engine/index_progress_test.go
@@ -12,8 +12,9 @@ import (
 func TestProgressStoreDeepCopy(t *testing.T) {
 	store := newProgressStore()
 	now := time.Now()
+	wsRoot := t.TempDir()
 
-	store.start("ws1", "/tmp/ws1", "job1", now)
+	store.start("ws1", wsRoot, "job1", now)
 	store.update("ws1", "go", 5, 10, now)
 
 	p := store.get("ws1", "")
@@ -73,10 +74,11 @@ func TestProgressStoreDiskRoundTrip(t *testing.T) {
 func TestProgressStoreGlobalPercent(t *testing.T) {
 	store := newProgressStore()
 	now := time.Now()
+	wsRoot := t.TempDir()
 
-	store.start("ws1", "/tmp/ws1", "job1", now)
-	store.update("ws1", "md", 120, 120, now)  // md: 100% (120/120)
-	store.update("ws1", "go", 234, 500, now)  // go: 46%  (234/500)
+	store.start("ws1", wsRoot, "job1", now)
+	store.update("ws1", "md", 120, 120, now) // md: 100% (120/120)
+	store.update("ws1", "go", 234, 500, now) // go: 46%  (234/500)
 
 	p := store.get("ws1", "")
 	if p == nil {
@@ -94,8 +96,9 @@ func TestProgressStoreGlobalPercent(t *testing.T) {
 func TestProgressStoreCurrentLanguage(t *testing.T) {
 	store := newProgressStore()
 	now := time.Now()
+	wsRoot := t.TempDir()
 
-	store.start("ws2", "/tmp/ws2", "job2", now)
+	store.start("ws2", wsRoot, "job2", now)
 	store.update("ws2", "md", 10, 100, now)
 
 	p := store.get("ws2", "")
@@ -117,14 +120,17 @@ func TestProgressStoreCurrentLanguage(t *testing.T) {
 func TestProgressStoreTwoWorkspacesIsolated(t *testing.T) {
 	store := newProgressStore()
 	now := time.Now()
+	rootA := t.TempDir()
+	rootB := t.TempDir()
 
-	// WsA: go 50/100, python 0/200 → global = 50/300 = 16%
-	store.start("wsA", "/tmp/wsA", "jobA", now)
+	// WsA: go 50/100, python 0/200 → global = (50+0)/(100+200)*100 = 16%
+	// python is in the denominator because totals are pre-registered
+	store.start("wsA", rootA, "jobA", now)
 	store.update("wsA", "go", 50, 100, now)
 	store.update("wsA", "python", 0, 200, now)
 
 	// WsB: go 200/200 → global = 200/200 = 100%
-	store.start("wsB", "/tmp/wsB", "jobB", now)
+	store.start("wsB", rootB, "jobB", now)
 	store.update("wsB", "go", 200, 200, now)
 
 	pA := store.get("wsA", "")
@@ -167,8 +173,8 @@ func TestProgressStoreTwoWorkspacesConcurrent(t *testing.T) {
 	store := newProgressStore()
 	now := time.Now()
 
-	store.start("cA", "/tmp/cA", "jA", now)
-	store.start("cB", "/tmp/cB", "jB", now)
+	store.start("cA", t.TempDir(), "jA", now)
+	store.start("cB", t.TempDir(), "jB", now)
 
 	const iters = 50
 	done := make(chan struct{}, 2)

--- a/internal/service/engine/index_progress_test.go
+++ b/internal/service/engine/index_progress_test.go
@@ -109,3 +109,98 @@ func TestProgressStoreCurrentLanguage(t *testing.T) {
 		t.Errorf("expected CurrentLanguage='go', got %q", p.CurrentLanguage)
 	}
 }
+
+// TestProgressStoreTwoWorkspacesIsolated verifies that two workspaces updating
+// the store concurrently do not corrupt each other's GlobalPercent or Languages.
+// This covers the real production scenario: wsA and wsB indexing simultaneously
+// (allowed since indexingJobs dedup is per workspace ID, not global).
+func TestProgressStoreTwoWorkspacesIsolated(t *testing.T) {
+	store := newProgressStore()
+	now := time.Now()
+
+	// WsA: go 50/100, python 0/200 → global = 50/300 = 16%
+	store.start("wsA", "/tmp/wsA", "jobA", now)
+	store.update("wsA", "go", 50, 100, now)
+	store.update("wsA", "python", 0, 200, now)
+
+	// WsB: go 200/200 → global = 200/200 = 100%
+	store.start("wsB", "/tmp/wsB", "jobB", now)
+	store.update("wsB", "go", 200, 200, now)
+
+	pA := store.get("wsA", "")
+	pB := store.get("wsB", "")
+
+	if pA == nil || pB == nil {
+		t.Fatal("expected both workspaces to have progress, got nil")
+	}
+
+	// WsA: global = (50+0)/(100+200)*100 = 16
+	wantA := 16
+	if pA.GlobalPercent != wantA {
+		t.Errorf("wsA: expected GlobalPercent=%d, got %d", wantA, pA.GlobalPercent)
+	}
+
+	// WsB: global = 200/200*100 = 100
+	wantB := 100
+	if pB.GlobalPercent != wantB {
+		t.Errorf("wsB: expected GlobalPercent=%d, got %d", wantB, pB.GlobalPercent)
+	}
+
+	// WsA should NOT have python data from wsB and vice versa
+	if _, ok := pA.Languages["python"]; !ok {
+		// python was explicitly added to wsA with 0/200
+	}
+	if _, ok := pB.Languages["python"]; ok {
+		t.Error("wsB should not have python language (was only set on wsA)")
+	}
+
+	// Verify wsA progress is not polluted by wsB's go collection
+	if pA.Languages["go"].TotalFiles == 200 {
+		t.Error("wsA.go should have TotalFiles=100, not 200 (wsB pollution)")
+	}
+}
+
+// TestProgressStoreTwoWorkspacesConcurrent verifies no data races when two
+// workspaces update the store from separate goroutines simultaneously.
+// Run with -race to detect races.
+func TestProgressStoreTwoWorkspacesConcurrent(t *testing.T) {
+	store := newProgressStore()
+	now := time.Now()
+
+	store.start("cA", "/tmp/cA", "jA", now)
+	store.start("cB", "/tmp/cB", "jB", now)
+
+	const iters = 50
+	done := make(chan struct{}, 2)
+
+	go func() {
+		for i := 0; i < iters; i++ {
+			store.update("cA", "go", i, iters, time.Now())
+		}
+		done <- struct{}{}
+	}()
+
+	go func() {
+		for i := 0; i < iters; i++ {
+			store.update("cB", "python", i, iters, time.Now())
+		}
+		done <- struct{}{}
+	}()
+
+	<-done
+	<-done
+
+	pA := store.get("cA", "")
+	pB := store.get("cB", "")
+
+	if pA == nil || pB == nil {
+		t.Fatal("expected progress for both workspaces after concurrent updates")
+	}
+	// After 50 updates each, final state should be 49/50 for each
+	if pA.Languages["go"].DoneFiles != iters-1 {
+		t.Errorf("wsA go: expected done=%d, got %d", iters-1, pA.Languages["go"].DoneFiles)
+	}
+	if pB.Languages["python"].DoneFiles != iters-1 {
+		t.Errorf("wsB python: expected done=%d, got %d", iters-1, pB.Languages["python"].DoneFiles)
+	}
+}

--- a/pkg/indexer/service.go
+++ b/pkg/indexer/service.go
@@ -22,7 +22,6 @@ import (
 	"github.com/doITmagic/rag-code-mcp/pkg/storage"
 )
 
-
 const (
 	deleteCollectionTimeout = 10 * time.Second
 	deleteCollectionMaxWait = 500 * time.Millisecond
@@ -585,4 +584,36 @@ func (s *Service) symbolToMap(sym parser.Symbol) map[string]interface{} {
 		}
 	}
 	return res
+}
+
+// CountFiles returns the number of files in root that match the given language,
+// applying the same directory exclusion rules as IndexWorkspace.
+// It does NOT load state or call the embedder — it is a fast pre-scan used to
+// establish accurate global progress totals before indexing begins.
+func (s *Service) CountFiles(root, lang string, excludePatterns []string) int {
+	count := 0
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if strings.HasPrefix(name, ".") || name == "vendor" || name == "node_modules" {
+				return filepath.SkipDir
+			}
+			for _, p := range excludePatterns {
+				if name == p {
+					return filepath.SkipDir
+				}
+			}
+			return nil
+		}
+		a := parser.GetByFile(path)
+		if a == nil || (lang != "" && a.Name() != lang) {
+			return nil
+		}
+		count++
+		return nil
+	})
+	return count
 }

--- a/pkg/indexer/service.go
+++ b/pkg/indexer/service.go
@@ -220,15 +220,9 @@ func (s *Service) IndexWorkspace(ctx context.Context, root string, collection st
 	// here only added complexity without meaningful throughput gain.
 	var fileErrs []string
 	for _, path := range changedFiles {
-		n := int(doneFiles.Add(1))
-		pct := n * 100 / totalFiles
-
-		logger.Instance.Debug("[IDX] ws=%s lang=%s [%d/%d] %s (%d%%)",
-			wsName, opts.Language, n, totalFiles, filepath.Base(path), pct)
-
-		if opts.Progress != nil {
-			opts.Progress(n, totalFiles)
-		}
+		fileNum := int(doneFiles.Load()) + 1
+		logger.Instance.Debug("[IDX] ws=%s lang=%s [%d/%d] %s (indexing...)",
+			wsName, opts.Language, fileNum, totalFiles, filepath.Base(path))
 
 		symCount, indexErr := s.IndexFile(ctx, collection, path, state)
 		if indexErr != nil {
@@ -236,6 +230,14 @@ func (s *Service) IndexWorkspace(ctx context.Context, root string, collection st
 			fileErrs = append(fileErrs, fmt.Sprintf("%s: %v", path, indexErr))
 		} else {
 			logger.Instance.Debug("[IDX] ws=%s lang=%s %s → %d symbol(s)", wsName, opts.Language, filepath.Base(path), symCount)
+		}
+
+		// Increment after IndexFile so 100% is only reported once the last file is done.
+		n := int(doneFiles.Add(1))
+		pct := n * 100 / totalFiles
+		logger.Instance.Debug("[IDX] ws=%s lang=%s [%d/%d] done (%d%%)", wsName, opts.Language, n, totalFiles, pct)
+		if opts.Progress != nil {
+			opts.Progress(n, totalFiles)
 		}
 	}
 

--- a/pkg/indexer/service.go
+++ b/pkg/indexer/service.go
@@ -313,8 +313,6 @@ func (s *Service) IndexWorkspace(ctx context.Context, root string, collection st
 					pct = n * 100 / totalFiles
 				}
 
-				state.SetLastPercent(pct) // <-- SALVARE PROGRES!
-
 				logger.Instance.Info("📄 [%d/%d] %s (%s, %d%%)", n, totalFiles, filepath.Base(path), opts.Language, pct)
 				if opts.Progress != nil {
 					opts.Progress(n, totalFiles)

--- a/pkg/indexer/service.go
+++ b/pkg/indexer/service.go
@@ -586,12 +586,12 @@ func (s *Service) symbolToMap(sym parser.Symbol) map[string]interface{} {
 	return res
 }
 
-// CountFiles returns the number of files in root that match the given language,
+// CountAllFiles counts files per language in root using a single WalkDir pass,
 // applying the same directory exclusion rules as IndexWorkspace.
-// It does NOT load state or call the embedder — it is a fast pre-scan used to
-// establish accurate global progress totals before indexing begins.
-func (s *Service) CountFiles(root, lang string, excludePatterns []string) int {
-	count := 0
+// It returns a map[langName]count that can be used to pre-populate progress
+// totals before indexing begins, avoiding O(languages × files) traversals.
+func (s *Service) CountAllFiles(root string, excludePatterns []string) map[string]int {
+	counts := make(map[string]int)
 	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return nil
@@ -609,11 +609,11 @@ func (s *Service) CountFiles(root, lang string, excludePatterns []string) int {
 			return nil
 		}
 		a := parser.GetByFile(path)
-		if a == nil || (lang != "" && a.Name() != lang) {
+		if a == nil {
 			return nil
 		}
-		count++
+		counts[a.Name()]++
 		return nil
 	})
-	return count
+	return counts
 }

--- a/pkg/indexer/service.go
+++ b/pkg/indexer/service.go
@@ -22,76 +22,6 @@ import (
 	"github.com/doITmagic/rag-code-mcp/pkg/storage"
 )
 
-// getSystemMemoryGB attempts to read total system memory from /proc/meminfo (Linux).
-// Returns 0 if unable to read.
-func getSystemMemoryGB() int {
-	if runtime.GOOS != "linux" {
-		return 0
-	}
-	data, err := os.ReadFile("/proc/meminfo")
-	if err != nil {
-		return 0
-	}
-	lines := strings.Split(string(data), "\n")
-	for _, line := range lines {
-		if strings.HasPrefix(line, "MemTotal:") {
-			var kb int
-			if _, err := fmt.Sscanf(line, "MemTotal: %d kB", &kb); err == nil {
-				return kb / (1024 * 1024)
-			}
-		}
-	}
-	return 0
-}
-
-// globalIndexSemaphore limits the total number of concurrent file-indexing workers
-// across ALL active workspace indexing jobs.
-// To prevent Ollama OOM while maximizing speed, we scale concurrency based on system RAM:
-// - <= 8GB  RAM: 1 worker  (Survival mode)
-// - <= 16GB RAM: 2 workers
-// - <= 32GB RAM: 3 workers
-// - > 32GB  RAM: 4 workers (Max Cap for high-end systems to leave RAM for OS/IDE)
-var globalIndexSemaphore = func() chan struct{} {
-	n := runtime.NumCPU() / 4
-	if n < 2 {
-		n = 2
-	}
-	if n > 4 {
-		n = 4
-	}
-
-	memGB := getSystemMemoryGB()
-	if memGB > 0 {
-		var ramWorkers int
-		switch {
-		case memGB <= 8:
-			ramWorkers = 1
-		case memGB <= 16:
-			ramWorkers = 2
-		case memGB <= 32:
-			ramWorkers = 3
-		default:
-			ramWorkers = 4
-		}
-
-		// Take the minimum between CPU-recommended workers and RAM-allowed workers
-		if ramWorkers < n {
-			n = ramWorkers
-		}
-
-		logger.Instance.Info("🧠 Detected %dGB RAM. Dynamic indexing concurrency set to %d workers.", memGB, n)
-	} else {
-		// Fallback for non-Linux or failures, strictly safe
-		logger.Instance.Warn("🧠 Could not detect system RAM. Defaulting to safe concurrency limit of 1 worker.")
-		n = 1
-	}
-
-	ch := make(chan struct{}, n)
-	for i := 0; i < n; i++ {
-		ch <- struct{}{}
-	}
-	return ch
-}()
 
 const (
 	deleteCollectionTimeout = 10 * time.Second
@@ -101,6 +31,7 @@ const (
 // Options configures the indexer.
 type Options struct {
 	Language        string
+	WorkspaceName   string // basename of workspace root, used for logging
 	ExcludePatterns []string
 	Recreate        bool
 	Progress        func(doneFiles, totalFiles int)
@@ -220,34 +151,25 @@ func (s *Service) IndexWorkspace(ctx context.Context, root string, collection st
 		}
 	}
 
+	wsName := opts.WorkspaceName
+	if wsName == "" {
+		wsName = filepath.Base(root)
+	}
+
 	totalFiles := len(changedFiles)
-	logger.Instance.Info("Indexing %d file(s) in %s (Language: %s)", totalFiles, root, opts.Language)
+	logger.Instance.Info("[IDX] ws=%s lang=%s ▶ %d file(s) to index", wsName, opts.Language, totalFiles)
 
 	// Ensure the embedding model is loaded in Ollama's memory before starting.
 	// If another program evicted it, this will reload it (with up to 2min timeout).
 	if ollamaProvider, ok := unwrapOllamaProvider(s.embedder); ok {
 		if err := ollamaProvider.EnsureLoaded(ctx); err != nil {
-			logger.Instance.Error("Cannot ensure embedding model is loaded: %v", err)
+			logger.Instance.Error("[IDX] ws=%s lang=%s ❌ embedding model not available: %v", wsName, opts.Language, err)
 			return fmt.Errorf("embedding model not available: %w", err)
 		}
 	}
 
-	// 4. Process changed files using the global semaphore to cap total concurrency
-	// across all active workspace indexing jobs (prevents CPU/RAM overload).
-	numFileWorkers := cap(globalIndexSemaphore)
-
-	filePaths := make(chan string, totalFiles)
-	for _, p := range changedFiles {
-		filePaths <- p
-	}
-	close(filePaths)
-
-	var (
-		fileWg    sync.WaitGroup
-		errMu     sync.Mutex
-		fileErrs  []string
-		doneFiles atomic.Int64
-	)
+	// 4. File-level counters for watchdog (accessed from two goroutines via atomic).
+	var doneFiles atomic.Int64
 
 	// Dedicated periodic-save goroutine + stall watchdog: detects silent deadlocks.
 	saveStop := make(chan struct{})
@@ -261,35 +183,29 @@ func (s *Service) IndexWorkspace(ctx context.Context, root string, collection st
 			select {
 			case <-saveTicker.C:
 				if err := state.Save(statePath); err != nil {
-					logger.Instance.Warn("Periodic state save failed for %s: %v", root, err)
+					logger.Instance.Warn("[IDX] ws=%s lang=%s periodic state save failed: %v", wsName, opts.Language, err)
 				}
 			case <-stallTicker.C:
 				current := doneFiles.Load()
-				// We only trigger stall logic if we haven't finished all files AND
-				// we haven't successfully embedded ANY new symbol in the last 60 seconds.
 				lastActivitySec := s.lastActivity.Load()
 				elapsedSinceActivity := time.Now().Unix() - lastActivitySec
 
 				if current < int64(totalFiles) && elapsedSinceActivity >= 60 {
 					stallCount++
-					semLen := len(globalIndexSemaphore)
-					semCap := cap(globalIndexSemaphore)
-					logger.Instance.Warn("⚠️ Indexing stall detected for %s/%s: %d/%d files. No embed activity for %ds. Semaphore: %d/%d. Stall count: %d",
-						opts.Language, root, current, totalFiles, elapsedSinceActivity, semLen, semCap, stallCount)
+					logger.Instance.Warn("[IDX] ws=%s lang=%s ⚠️ STALL: no embed activity for %ds [%d/%d] (stall #%d)",
+						wsName, opts.Language, elapsedSinceActivity, current, totalFiles, stallCount)
 					if stallCount >= 2 {
-						// Check if Ollama is still alive
 						if err := healthcheck.PingOllama(""); err != nil {
-							logger.Instance.Error("🔴 Ollama HTTP is unresponsive (%v). Forcing restart...", err)
+							logger.Instance.Error("[IDX] ws=%s lang=%s ❌ Ollama unresponsive: %v — forcing restart", wsName, opts.Language, err)
 						} else {
-							logger.Instance.Error("🔴 Ollama HTTP ping is OK but embedding goroutines are DEADLOCKED. Forcing restart!")
+							logger.Instance.Error("[IDX] ws=%s lang=%s ❌ Ollama ping OK but embed goroutine STALLED — forcing restart", wsName, opts.Language)
 						}
-						// Always attempt strict restart to kill stuck runners
 						attemptOllamaRestart()
 					}
 					if stallCount >= 3 {
 						buf := make([]byte, 8192)
 						n := runtime.Stack(buf, true)
-						logger.Instance.Error("🔴 Deadlock confirmed in indexing goroutines for %s. Goroutine dump:\n%s", root, string(buf[:n]))
+						logger.Instance.Error("[IDX] ws=%s lang=%s goroutine dump:\n%s", wsName, opts.Language, string(buf[:n]))
 					}
 				} else {
 					stallCount = 0
@@ -300,53 +216,42 @@ func (s *Service) IndexWorkspace(ctx context.Context, root string, collection st
 		}
 	}()
 
-	for i := 0; i < numFileWorkers; i++ {
-		fileWg.Add(1)
-		go func() {
-			defer fileWg.Done()
-			for path := range filePaths {
-				// Acquire global slot — blocks if too many concurrent indexers active
-				<-globalIndexSemaphore
-				n := int(doneFiles.Add(1))
-				pct := 0
-				if totalFiles > 0 {
-					pct = n * 100 / totalFiles
-				}
+	// 5. Sequential file processing — no worker pool, no semaphore.
+	// Embed is serial in Ollama anyway (numWorkers=1 in IndexItems), so parallelism
+	// here only added complexity without meaningful throughput gain.
+	var fileErrs []string
+	for _, path := range changedFiles {
+		n := int(doneFiles.Add(1))
+		pct := n * 100 / totalFiles
 
-				logger.Instance.Info("📄 [%d/%d] %s (%s, %d%%)", n, totalFiles, filepath.Base(path), opts.Language, pct)
-				if opts.Progress != nil {
-					opts.Progress(n, totalFiles)
-				}
+		logger.Instance.Debug("[IDX] ws=%s lang=%s [%d/%d] %s (%d%%)",
+			wsName, opts.Language, n, totalFiles, filepath.Base(path), pct)
 
-				symCount, indexErr := s.IndexFile(ctx, collection, path, state)
-				// Release slot immediately after processing
-				globalIndexSemaphore <- struct{}{}
+		if opts.Progress != nil {
+			opts.Progress(n, totalFiles)
+		}
 
-				if indexErr != nil {
-					logger.Instance.Error("Failed to index %s: %v", path, indexErr)
-					errMu.Lock()
-					fileErrs = append(fileErrs, fmt.Sprintf("%s: %v", path, indexErr))
-					errMu.Unlock()
-				} else {
-					logger.Instance.Info("  → %d symbol(s) indexed from %s", symCount, filepath.Base(path))
-				}
-			}
-		}()
+		symCount, indexErr := s.IndexFile(ctx, collection, path, state)
+		if indexErr != nil {
+			logger.Instance.Warn("[IDX] ws=%s lang=%s ⚠️ %s: %v", wsName, opts.Language, filepath.Base(path), indexErr)
+			fileErrs = append(fileErrs, fmt.Sprintf("%s: %v", path, indexErr))
+		} else {
+			logger.Instance.Debug("[IDX] ws=%s lang=%s %s → %d symbol(s)", wsName, opts.Language, filepath.Base(path), symCount)
+		}
 	}
 
-	fileWg.Wait()
-	close(saveStop) // Stop the periodic save goroutine
-	logger.Instance.Info("[INDEX] %s done: %d file(s) indexed", opts.Language, totalFiles)
+	close(saveStop)
 
 	if len(fileErrs) > 0 {
-		logger.Instance.Warn("%d file(s) failed to index in %s", len(fileErrs), root)
+		logger.Instance.Warn("[IDX] ws=%s lang=%s %d file(s) failed to index", wsName, opts.Language, len(fileErrs))
 	}
 
-	// 5. Save state
+	// 6. Save state
 	if err := state.Save(statePath); err != nil {
-		logger.Instance.Warn("Failed to save index state for %s: %v", root, err)
+		logger.Instance.Warn("[IDX] ws=%s lang=%s failed to save state: %v", wsName, opts.Language, err)
 	}
 
+	logger.Instance.Info("[IDX] ws=%s lang=%s ✅ DONE %d file(s)", wsName, opts.Language, totalFiles)
 	return nil
 }
 

--- a/pkg/indexer/service_test.go
+++ b/pkg/indexer/service_test.go
@@ -156,9 +156,9 @@ func TestIndexItemsParallelism(t *testing.T) {
 	Expect(len(mockS.upsertPoints)).To(Equal(100))
 }
 
-// TestIndexWorkspaceParallelFiles verifies that multiple files are indexed concurrently
-// with no data races on shared state. Run with -race to detect races.
-func TestIndexWorkspaceParallelFiles(t *testing.T) {
+// TestIndexWorkspaceSequentialFiles verifies that multiple files are indexed correctly
+// in a sequential for loop. Run with -race to detect races on shared state.
+func TestIndexWorkspaceSequentialFiles(t *testing.T) {
 	RegisterTestingT(t)
 
 	// One file per sub-package directory so each IndexFile call yields exactly 1 symbol.
@@ -179,7 +179,7 @@ func TestIndexWorkspaceParallelFiles(t *testing.T) {
 	mockS := &mockStore{}
 	svc := NewService(mockEmbed, mockS)
 
-	err := svc.IndexWorkspace(context.Background(), dir, "test-parallel", Options{Language: "go"})
+	err := svc.IndexWorkspace(context.Background(), dir, "test-sequential", Options{Language: "go"})
 	Expect(err).NotTo(HaveOccurred())
 
 	// Each sub-package has 1 function → numFiles symbols total
@@ -191,56 +191,51 @@ func TestIndexWorkspaceParallelFiles(t *testing.T) {
 	Expect(int(atomic.LoadInt32(&mockEmbed.embedCount))).To(BeNumerically(">=", numFiles))
 }
 
-// TestGlobalSemaphoreOrder verifies that the semaphore protocol is correct:
-// acquire = receive a token (<-ch), release = send a token back (ch <- struct{}{}).
-// A pre-filled buffered channel of capacity N means N concurrent workers can acquire.
-// If acquire/release were swapped, this test would deadlock and be caught by the timeout.
-func TestGlobalSemaphoreOrder(t *testing.T) {
+// TestIndexWorkspaceProgressIsAscending verifies that Progress callback is called
+// in strictly ascending order — guaranteed by the sequential for loop.
+func TestIndexWorkspaceProgressIsAscending(t *testing.T) {
 	RegisterTestingT(t)
 
-	const cap = 3
-	sem := make(chan struct{}, cap)
-	// Pre-fill: each token represents a free slot.
-	for i := 0; i < cap; i++ {
-		sem <- struct{}{}
+	dir := t.TempDir()
+	const numFiles = 5
+	for i := 0; i < numFiles; i++ {
+		pkgDir := filepath.Join(dir, fmt.Sprintf("ppkg%d", i))
+		Expect(os.MkdirAll(pkgDir, 0755)).To(Succeed())
+		src := fmt.Sprintf("package ppkg%d\n\nfunc PF%d() {}\n", i, i)
+		Expect(os.WriteFile(filepath.Join(pkgDir, "f.go"), []byte(src), 0644)).To(Succeed())
 	}
 
-	// Acquire all N tokens — should not block.
-	for i := 0; i < cap; i++ {
-		select {
-		case <-sem: // acquire = receive
-		default:
-			t.Fatalf("acquire %d should not block on a fresh semaphore", i)
-		}
-	}
+	var calls []int
+	var mu sync.Mutex
 
-	// Semaphore empty — next acquire MUST block.
-	select {
-	case <-sem:
-		t.Fatal("acquire should block when semaphore is exhausted")
-	default:
-		// expected — would block
-	}
+	mockEmbed := &mockEmbedder{}
+	mockS := &mockStore{}
+	svc := NewService(mockEmbed, mockS)
 
-	// Release one slot.
-	sem <- struct{}{} // release = send
+	err := svc.IndexWorkspace(context.Background(), dir, "test-ascending", Options{
+		Language: "go",
+		Progress: func(done, total int) {
+			mu.Lock()
+			calls = append(calls, done)
+			mu.Unlock()
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(len(calls)).To(Equal(numFiles))
 
-	// Now acquire should succeed again.
-	select {
-	case <-sem:
-		// OK
-	default:
-		t.Fatal("acquire should succeed after release")
+	// Sequential: each call must increment by exactly 1
+	for i := 1; i < len(calls); i++ {
+		Expect(calls[i]).To(Equal(calls[i-1]+1), "progress calls must be strictly ascending")
 	}
 }
 
 // TestIndexWorkspaceNoDeadlock runs IndexWorkspace with many files and a tight timeout.
-// If the semaphore is inverted (the original bug), this will deadlock and fail via timeout.
+// With the sequential model there is no semaphore to deadlock, but this verifies
+// that IndexWorkspace completes within a reasonable time.
 func TestIndexWorkspaceNoDeadlock(t *testing.T) {
 	RegisterTestingT(t)
 
 	dir := t.TempDir()
-	// Create more files than the semaphore capacity to trigger contention.
 	const numFiles = 20
 	for i := 0; i < numFiles; i++ {
 		pkgDir := filepath.Join(dir, fmt.Sprintf("dpkg%d", i))
@@ -264,7 +259,7 @@ func TestIndexWorkspaceNoDeadlock(t *testing.T) {
 	case err := <-done:
 		Expect(err).NotTo(HaveOccurred())
 	case <-time.After(30 * time.Second):
-		t.Fatal("IndexWorkspace deadlocked — semaphore acquire/release likely inverted")
+		t.Fatal("IndexWorkspace took too long — possible infinite loop or deadlock")
 	}
 
 	mockS.mu.Lock()

--- a/pkg/indexer/state.go
+++ b/pkg/indexer/state.go
@@ -17,10 +17,10 @@ type FileState struct {
 }
 
 // State represents the persistent state of a workspace index.
+// Note: progress tracking (percent) is handled by index_status.json via progressStore, not here.
 type State struct {
-	LastPercent int                  `json:"last_percent"` // 0-100 indicating global progress
-	Files       map[string]FileState `json:"files"`
-	mu          sync.RWMutex
+	Files map[string]FileState `json:"files"`
+	mu    sync.RWMutex
 }
 
 // NewState creates a new, empty index state.
@@ -109,9 +109,4 @@ func (s *State) IsChanged(path string, info os.FileInfo) bool {
 	return !info.ModTime().Equal(state.ModTime) || info.Size() != state.Size
 }
 
-// SetLastPercent updates the global indexing percentage.
-func (s *State) SetLastPercent(percent int) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.LastPercent = percent
-}
+

--- a/pkg/indexer/state_test.go
+++ b/pkg/indexer/state_test.go
@@ -1,0 +1,17 @@
+package indexer
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateHasNoLastPercent(t *testing.T) {
+	s := NewState()
+	data, err := json.Marshal(s)
+	require.NoError(t, err)
+	// LastPercent must NOT be serialized — progress tracking moved to index_status.json
+	assert.NotContains(t, string(data), "last_percent")
+}


### PR DESCRIPTION
## Description

Refactors the multi-collection indexing system to fix inaccurate progress reporting
and simplify the goroutine model.

**Root cause:** state.json stored last_percent as a per-language value. When
indexing multiple languages sequentially (md → go → python → ...), progress reset
to 0% with each new language. The search logic misread this as an interrupted
session and returned false ErrIndexingInProgress errors at >80% completion.

### Changes

**1. Remove last_percent from state.json**
- LastPercent field and SetLastPercent() removed from State struct
- state.json now exclusively tracks file fingerprints (modtime/size)

**2. Replace globalIndexSemaphore + worker pool with a sequential for loop**
- Removed RAM-based channel semaphore (1–4 workers based on memory)
- Removed file worker pool (N goroutines x 5 languages x N workspaces)
- Replaced with a simple for loop over changed files
- Goroutine count drops from 2+N*5 to **3 fixed goroutines**
- No performance regression: embedding was already serial at Ollama

**3. Accurate GlobalPercent + CurrentLanguage in index_status.json**
- GlobalPercent = sum(done_all_langs) / sum(total_all_langs) * 100
- CurrentLanguage tracks which language is actively being indexed
- update() uses 500ms debounced flush (hot path); complete()/fail() write synchronously

**4. Auto-resume from index_status.json**
- SearchCode and HybridSearchCode read GlobalPercent from index_status.json
- If 1 <= GlobalPercent <= 99 and state == "running" → background re-index triggered
- 5-minute cooldown prevents resuming the same workspace repeatedly

**5. Standardized logging**
- All log.Printf replaced with logger.Instance (removes "log" import)
- TIMER logs → Debug (hidden by default), INFO → Info, WARN → Warn, ERROR → Error
- Consistent format: [IDX] ws=<name> lang=<lang> [n/total] file (pct%)

**6. Debug visibility for concurrent workspaces**
- ActiveIndexingJobs() []string — exposes which workspaces are currently indexing
- Warn log when 2+ workspaces index simultaneously (Ollama contention alert)
- Multi-workspace isolation and race-condition tests (verified with -race)

**Design doc:** docs/plans/2026-03-07-indexing-overhaul-design.md

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have formatted my code with go fmt ./...
- [x] I have run tests go test ./... and they pass
- [ ] I have verified integration with Ollama/Qdrant (if applicable)
- [x] I have updated the documentation accordingly
