### PR TITLE
feat(search): Implement semantic chunk merging and strict search modes

### DIFF
--- a/internal/service/tools/smart_search.go
+++ b/internal/service/tools/smart_search.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -98,6 +99,12 @@ func (t *SmartSearchTool) Execute(ctx context.Context, input SmartSearchInput) (
 		limit = input.Limit
 	}
 
+	// When strict_docs mode is requested, automatically enable docs search
+	// so that the semantic engine actually fetches documentation results.
+	if input.Mode == "strict_docs" {
+		input.IncludeDocs = true
+	}
+
 	// Run both search strategies in parallel
 	type searchResult struct {
 		label   string
@@ -180,12 +187,13 @@ func (t *SmartSearchTool) Execute(ctx context.Context, input SmartSearchInput) (
 	// Apply mode filtering
 	var filtered []mergedResult
 	for _, m := range merged {
-		// Strict code mode: ignore completely any markdown or documentation type
-		if input.Mode == "strict_code" && (m.symbolType == "documentation" || m.symbolType == "markdown" || m.symbolType == "code_block" || strings.HasSuffix(strings.ToLower(m.filePath), ".md") || strings.HasSuffix(strings.ToLower(m.filePath), ".html")) {
+		isDoc := isDocSymbolType(m.symbolType) || isDocExtension(m.filePath)
+		// Strict code mode: ignore completely any documentation type or doc file
+		if input.Mode == "strict_code" && isDoc {
 			continue
 		}
 		// Strict docs mode: ignore anything that isn't documentation
-		if input.Mode == "strict_docs" && !(m.symbolType == "documentation" || m.symbolType == "markdown" || m.symbolType == "code_block" || strings.HasSuffix(strings.ToLower(m.filePath), ".md") || strings.HasSuffix(strings.ToLower(m.filePath), ".html")) {
+		if input.Mode == "strict_docs" && !isDoc {
 			continue
 		}
 		filtered = append(filtered, m)
@@ -481,26 +489,56 @@ func (t *SmartSearchTool) handleSearchError(err error, workspaceRoot, workspaceI
 	return response.JSON()
 }
 
-// readLines reads a specific range of lines from a file.
-// Lines are 1-indexed.
+// isDocSymbolType returns true if the symbol type represents documentation content.
+func isDocSymbolType(symbolType string) bool {
+	return symbolType == "documentation" || symbolType == "code_block" || symbolType == "markdown"
+}
+
+// isDocExtension returns true if the file path has a documentation or structured text extension.
+func isDocExtension(filePath string) bool {
+	ext := strings.ToLower(filepath.Ext(filePath))
+	switch ext {
+	case ".md", ".markdown", ".html", ".htm",
+		".yaml", ".yml", ".json", ".xml",
+		".toml", ".rst":
+		return true
+	}
+	return false
+}
+
+// readLines reads a specific range of lines from a file using a buffered scanner
+// to avoid loading the entire file into memory. Lines are 1-indexed.
 func readLines(filePath string, startLine, endLine int) (string, error) {
-	content, err := os.ReadFile(filePath)
+	if startLine < 1 || endLine < startLine {
+		return "", fmt.Errorf("invalid line range %d-%d", startLine, endLine)
+	}
+
+	f, err := os.Open(filePath)
 	if err != nil {
 		return "", err
 	}
-	
-	lines := strings.Split(string(content), "\n")
-	if startLine < 1 {
-		startLine = 1
+	defer f.Close()
+
+	var collected []string
+	scanner := bufio.NewScanner(f)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		if lineNum > endLine {
+			break
+		}
+		if lineNum >= startLine {
+			collected = append(collected, scanner.Text())
+		}
 	}
-	if endLine > len(lines) {
-		endLine = len(lines)
+	if err := scanner.Err(); err != nil {
+		return "", err
 	}
-	if startLine > endLine || startLine > len(lines) {
-		return "", fmt.Errorf("invalid line range")
+	if len(collected) == 0 {
+		return "", fmt.Errorf("invalid line range: file has %d lines, requested %d-%d", lineNum, startLine, endLine)
 	}
-	
-	return strings.Join(lines[startLine-1:endLine], "\n"), nil
+
+	return strings.Join(collected, "\n"), nil
 }
 
 // groupDocsByTree aggregates "documentation" and "code_block" chunks
@@ -512,39 +550,35 @@ func (t *SmartSearchTool) groupDocsByTree(results []mergedResult) []mergedResult
 	}
 
 	var out []mergedResult
-	
-	// Groups are keyed by: filePath_|_signature -> slice of mergedResult indices in groups slice
-	type docGroup struct {
+
+	type groupKey struct {
 		filePath  string
 		signature string
-		items     []*mergedResult
-		maxScore  float32
-		minLine   int
-		maxLine   int
-		source    string
 	}
-	
-	groupsMap := make(map[string]*docGroup)
-	var orderedGroups []string // keep track of the first time we see a group to maintain rough sorting
+
+	type docGroup struct {
+		key      groupKey
+		items    []*mergedResult
+		maxScore float32
+		minLine  int
+		maxLine  int
+		source   string
+	}
+
+	groupsMap := make(map[groupKey]*docGroup)
+	var orderedGroups []groupKey // keep track of the first time we see a group to maintain rough sorting
 
 	for i := range results {
 		res := &results[i]
-		
-		// Only group documentation types and files ending in .md or .html
-		ext := strings.ToLower(filepath.Ext(res.filePath))
-		isDocFile := ext == ".md" || ext == ".markdown" || ext == ".html" || ext == ".htm" || 
-			ext == ".yaml" || ext == ".yml" || ext == ".json" || ext == ".xml" || 
-			ext == ".toml" || ext == ".rst" || ext == ".css" || ext == ".scss" || ext == ".svelte" || ext == ".sql" || ext == ".sh"
-		
-		isDocType := res.symbolType == "documentation" || res.symbolType == "code_block" || res.symbolType == "markdown"
-		
-		if !isDocType || !isDocFile || res.signature == "" {
+
+		// Only group documentation types and documentation/structured text files
+		if !isDocSymbolType(res.symbolType) || !isDocExtension(res.filePath) || res.signature == "" {
 			// Pass-through code or items without signature
 			out = append(out, *res)
 			continue
 		}
-		
-		key := fmt.Sprintf("%s_|_%s", res.filePath, res.signature)
+
+		key := groupKey{filePath: res.filePath, signature: res.signature}
 		if g, exists := groupsMap[key]; exists {
 			g.items = append(g.items, res)
 			if res.score > g.maxScore {
@@ -569,13 +603,12 @@ func (t *SmartSearchTool) groupDocsByTree(results []mergedResult) []mergedResult
 				maxL = 1
 			}
 			groupsMap[key] = &docGroup{
-				filePath:  res.filePath,
-				signature: res.signature,
-				items:     []*mergedResult{res},
-				maxScore:  res.score,
-				minLine:   minL,
-				maxLine:   maxL,
-				source:    res.source,
+				key:      key,
+				items:    []*mergedResult{res},
+				maxScore: res.score,
+				minLine:  minL,
+				maxLine:  maxL,
+				source:   res.source,
 			}
 			orderedGroups = append(orderedGroups, key)
 		}
@@ -584,23 +617,23 @@ func (t *SmartSearchTool) groupDocsByTree(results []mergedResult) []mergedResult
 	// Reconstruct the grouped items
 	for _, key := range orderedGroups {
 		g := groupsMap[key]
-		
+
 		if len(g.items) == 1 {
 			// Nothing to merge, just append
 			out = append(out, *g.items[0])
 			continue
 		}
-		
+
 		// Multiple chunks in this group. Let's merge them!
 		// Attempt to read the full continuous block from the file
 		fullContent := ""
 		if g.minLine > 0 && g.maxLine >= g.minLine {
-			content, err := readLines(g.filePath, g.minLine, g.maxLine)
+			content, err := readLines(g.key.filePath, g.minLine, g.maxLine)
 			if err == nil {
 				fullContent = content
 			}
 		}
-		
+
 		// If reading from disk failed, append the contents manually with an ellipsis
 		if fullContent == "" {
 			var contents []string
@@ -620,10 +653,10 @@ func (t *SmartSearchTool) groupDocsByTree(results []mergedResult) []mergedResult
 		merged := mergedResult{
 			id:         fmt.Sprintf("merged_%s_%d_%d", baseItem.id, g.minLine, g.maxLine),
 			score:      g.maxScore,
-			filePath:   g.filePath,
+			filePath:   g.key.filePath,
 			name:       baseItem.name,
 			symbolType: "documentation_merged",
-			signature:  g.signature,
+			signature:  g.key.signature,
 			pkg:        baseItem.pkg,
 			docstring:  fmt.Sprintf("Merged %d chunks spanning %d lines.", len(g.items), g.maxLine-g.minLine+1),
 			content:    fullContent,

--- a/internal/service/tools/smart_search.go
+++ b/internal/service/tools/smart_search.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -42,7 +43,10 @@ func (t *SmartSearchTool) Description() string {
 		"high-confidence matches return full source code, exploratory results return compact summaries. " +
 		"No need to choose a search mode. Provide 'file_path' for faster workspace detection, or omit it for Auto-Discovery. " +
 		"Set 'include_full_content' to true to force full source code in all results, overriding compact mode. " +
-		"Set 'include_docs' to true to also search project documentation (README, guides, Markdown files) alongside code."
+		"Set 'include_docs' to true to also search project documentation (README, guides, Markdown files) alongside code. " +
+		"Use 'mode'=\"strict_code\" when you ONLY want to see implementation logic exactly (Go, Python, etc) and strictly ignore documentation. " +
+		"Use 'mode'=\"strict_docs\" when searching for architectural plans or summaries. " +
+		"Use 'mode'=\"all\" or omit for broad scans."
 }
 
 type SmartSearchInput struct {
@@ -51,6 +55,7 @@ type SmartSearchInput struct {
 	Limit              int    `json:"limit,omitempty"`
 	IncludeFullContent bool   `json:"include_full_content,omitempty"`
 	IncludeDocs        bool   `json:"include_docs,omitempty"`
+	Mode               string `json:"mode,omitempty"`
 }
 
 // highConfidenceThreshold: if top result score exceeds this, return full content.
@@ -171,6 +176,24 @@ func (t *SmartSearchTool) Execute(ctx context.Context, input SmartSearchInput) (
 
 	// Merge and deduplicate results from both strategies
 	merged := t.mergeResults(semanticRes, hybridRes, limit)
+
+	// Apply mode filtering
+	var filtered []mergedResult
+	for _, m := range merged {
+		// Strict code mode: ignore completely any markdown or documentation type
+		if input.Mode == "strict_code" && (m.symbolType == "documentation" || m.symbolType == "markdown" || m.symbolType == "code_block" || strings.HasSuffix(strings.ToLower(m.filePath), ".md") || strings.HasSuffix(strings.ToLower(m.filePath), ".html")) {
+			continue
+		}
+		// Strict docs mode: ignore anything that isn't documentation
+		if input.Mode == "strict_docs" && !(m.symbolType == "documentation" || m.symbolType == "markdown" || m.symbolType == "code_block" || strings.HasSuffix(strings.ToLower(m.filePath), ".md") || strings.HasSuffix(strings.ToLower(m.filePath), ".html")) {
+			continue
+		}
+		filtered = append(filtered, m)
+	}
+	merged = filtered
+
+	// Apply tree-based grouping for documentation chunks
+	merged = t.groupDocsByTree(merged)
 
 	if len(merged) == 0 {
 		response := ToolResponse{
@@ -457,3 +480,165 @@ func (t *SmartSearchTool) handleSearchError(err error, workspaceRoot, workspaceI
 	response.Error = fmt.Sprintf("search failed: %v", err)
 	return response.JSON()
 }
+
+// readLines reads a specific range of lines from a file.
+// Lines are 1-indexed.
+func readLines(filePath string, startLine, endLine int) (string, error) {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+	
+	lines := strings.Split(string(content), "\n")
+	if startLine < 1 {
+		startLine = 1
+	}
+	if endLine > len(lines) {
+		endLine = len(lines)
+	}
+	if startLine > endLine || startLine > len(lines) {
+		return "", fmt.Errorf("invalid line range")
+	}
+	
+	return strings.Join(lines[startLine-1:endLine], "\n"), nil
+}
+
+// groupDocsByTree aggregates "documentation" and "code_block" chunks
+// from the same file and AST Signature (Markdown heading) into single unified blocks,
+// fetching the continuous text from disk to prevent Frankenstein gaps.
+func (t *SmartSearchTool) groupDocsByTree(results []mergedResult) []mergedResult {
+	if len(results) == 0 {
+		return results
+	}
+
+	var out []mergedResult
+	
+	// Groups are keyed by: filePath_|_signature -> slice of mergedResult indices in groups slice
+	type docGroup struct {
+		filePath  string
+		signature string
+		items     []*mergedResult
+		maxScore  float32
+		minLine   int
+		maxLine   int
+		source    string
+	}
+	
+	groupsMap := make(map[string]*docGroup)
+	var orderedGroups []string // keep track of the first time we see a group to maintain rough sorting
+
+	for i := range results {
+		res := &results[i]
+		
+		// Only group documentation types and files ending in .md or .html
+		ext := strings.ToLower(filepath.Ext(res.filePath))
+		isDocFile := ext == ".md" || ext == ".markdown" || ext == ".html" || ext == ".htm" || 
+			ext == ".yaml" || ext == ".yml" || ext == ".json" || ext == ".xml" || 
+			ext == ".toml" || ext == ".rst" || ext == ".css" || ext == ".scss" || ext == ".svelte" || ext == ".sql" || ext == ".sh"
+		
+		isDocType := res.symbolType == "documentation" || res.symbolType == "code_block" || res.symbolType == "markdown"
+		
+		if !isDocType || !isDocFile || res.signature == "" {
+			// Pass-through code or items without signature
+			out = append(out, *res)
+			continue
+		}
+		
+		key := fmt.Sprintf("%s_|_%s", res.filePath, res.signature)
+		if g, exists := groupsMap[key]; exists {
+			g.items = append(g.items, res)
+			if res.score > g.maxScore {
+				g.maxScore = res.score
+			}
+			if res.startLine > 0 && (g.minLine == 0 || res.startLine < g.minLine) {
+				g.minLine = res.startLine
+			}
+			if res.endLine > 0 && res.endLine > g.maxLine {
+				g.maxLine = res.endLine
+			}
+			if g.source != "both" && g.source != res.source {
+				g.source = "both"
+			}
+		} else {
+			minL := res.startLine
+			if minL == 0 {
+				minL = 1
+			}
+			maxL := res.endLine
+			if maxL == 0 {
+				maxL = 1
+			}
+			groupsMap[key] = &docGroup{
+				filePath:  res.filePath,
+				signature: res.signature,
+				items:     []*mergedResult{res},
+				maxScore:  res.score,
+				minLine:   minL,
+				maxLine:   maxL,
+				source:    res.source,
+			}
+			orderedGroups = append(orderedGroups, key)
+		}
+	}
+
+	// Reconstruct the grouped items
+	for _, key := range orderedGroups {
+		g := groupsMap[key]
+		
+		if len(g.items) == 1 {
+			// Nothing to merge, just append
+			out = append(out, *g.items[0])
+			continue
+		}
+		
+		// Multiple chunks in this group. Let's merge them!
+		// Attempt to read the full continuous block from the file
+		fullContent := ""
+		if g.minLine > 0 && g.maxLine >= g.minLine {
+			content, err := readLines(g.filePath, g.minLine, g.maxLine)
+			if err == nil {
+				fullContent = content
+			}
+		}
+		
+		// If reading from disk failed, append the contents manually with an ellipsis
+		if fullContent == "" {
+			var contents []string
+			// Sort items by line number
+			sortedItems := make([]*mergedResult, len(g.items))
+			copy(sortedItems, g.items)
+			sort.Slice(sortedItems, func(i, j int) bool {
+				return sortedItems[i].startLine < sortedItems[j].startLine
+			})
+			for _, item := range sortedItems {
+				contents = append(contents, strings.TrimSpace(item.content))
+			}
+			fullContent = strings.Join(contents, "\n\n[...]\n\n")
+		}
+
+		baseItem := g.items[0] // take the first item as a prototype
+		merged := mergedResult{
+			id:         fmt.Sprintf("merged_%s_%d_%d", baseItem.id, g.minLine, g.maxLine),
+			score:      g.maxScore,
+			filePath:   g.filePath,
+			name:       baseItem.name,
+			symbolType: "documentation_merged",
+			signature:  g.signature,
+			pkg:        baseItem.pkg,
+			docstring:  fmt.Sprintf("Merged %d chunks spanning %d lines.", len(g.items), g.maxLine-g.minLine+1),
+			content:    fullContent,
+			startLine:  g.minLine,
+			endLine:    g.maxLine,
+			source:     g.source,
+		}
+		out = append(out, merged)
+	}
+
+	// After mixing merged chunks and original unmerged items, we should re-sort by score
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].score > out[j].score
+	})
+
+	return out
+}
+

--- a/internal/service/tools/smart_search_test.go
+++ b/internal/service/tools/smart_search_test.go
@@ -92,6 +92,82 @@ func TestGroupDocsByTree(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "Different files with same signature should NOT merge",
+			input: []mergedResult{
+				{
+					id: "1", filePath: "file1.md", symbolType: "documentation", signature: "### Intro",
+					startLine: 1, endLine: 3, score: 0.8,
+				},
+				{
+					id: "2", filePath: "file2.md", symbolType: "documentation", signature: "### Intro",
+					startLine: 4, endLine: 6, score: 0.9,
+				},
+			},
+			expected: 2, // Should stay separate because filePath differs
+			check: func(t *testing.T, results []mergedResult) {
+				if len(results) != 2 {
+					t.Fatalf("Expected 2 results, got %d", len(results))
+				}
+			},
+		},
+		{
+			name: "Gap retrieval works properly or falls back gracefully",
+			input: []mergedResult{
+				{
+					id: "c1", filePath: tempFilePath, symbolType: "documentation", signature: "### Test Gap",
+					startLine: 1, endLine: 2, score: 0.8, // Line A, B
+				},
+				{
+					id: "c2", filePath: tempFilePath, symbolType: "documentation", signature: "### Test Gap",
+					startLine: 19, endLine: 20, score: 0.9, // Line S, T
+				},
+			},
+			expected: 1, 
+			check: func(t *testing.T, results []mergedResult) {
+				if len(results) != 1 {
+					t.Fatalf("Expected 1 result after merge, got %d", len(results))
+				}
+				merged := results[0]
+				if merged.startLine != 1 || merged.endLine != 20 {
+					t.Errorf("Expected lines 1-20, got %d-%d", merged.startLine, merged.endLine)
+				}
+				// By our current logic it will attempt to fetch lines 1-20. Let's verify.
+				if !strings.Contains(merged.content, "Line F") {
+					t.Errorf("Expected merged content to fetch gap lines, but didn't find 'Line F'")
+				}
+			},
+		},
+		{
+			name: "Non-doc AST files (JSON, YAML) merge correctly if signature matches",
+			input: []mergedResult{
+				{
+					id: "y1", filePath: "config.yaml", symbolType: "documentation", signature: "server:",
+					startLine: 10, endLine: 12, score: 0.6, content: "port: 8080",
+				},
+				{
+					id: "y2", filePath: "config.yaml", symbolType: "documentation", signature: "server:",
+					startLine: 15, endLine: 18, score: 0.7, content: "host: localhost",
+				},
+			},
+			expected: 1,
+			check: func(t *testing.T, results []mergedResult) {
+				if len(results) != 1 {
+					t.Fatalf("Expected 1 result after merge, got %d", len(results))
+				}
+				// Because "config.yaml" doesn't actually exist on disk, we expect the fallback [...] logic!
+				merged := results[0]
+				if merged.startLine != 10 || merged.endLine != 18 {
+					t.Errorf("Expected lines 10-18, got %d-%d", merged.startLine, merged.endLine)
+				}
+				if !strings.Contains(merged.content, "port: 8080") || !strings.Contains(merged.content, "host: localhost") {
+					t.Errorf("Missing content in fake fallback merge")
+				}
+				if !strings.Contains(merged.content, "[...]") {
+					t.Errorf("Expected fallback [...] marker for missing file, got:\n%s", merged.content)
+				}
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/service/tools/smart_search_test.go
+++ b/internal/service/tools/smart_search_test.go
@@ -1,0 +1,106 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGroupDocsByTree(t *testing.T) {
+	// Create a temporary file for testing disk reads
+	tempDir := t.TempDir()
+	tempFilePath := filepath.Join(tempDir, "test_doc.md")
+	
+	// Create a dummy document with 20 lines
+	lines := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		lines[i] = "Line " + string(rune('A'+i)) // Line A, Line B, etc.
+	}
+	os.WriteFile(tempFilePath, []byte(strings.Join(lines, "\n")), 0644)
+
+	// Create tool instance (we only need the groupDocsByTree method)
+	tool := &SmartSearchTool{}
+
+	tests := []struct {
+		name     string
+		input    []mergedResult
+		expected int // Expected number of results after grouping
+		check    func(t *testing.T, results []mergedResult)
+	}{
+		{
+			name: "No grouping needed for code",
+			input: []mergedResult{
+				{id: "1", filePath: "main.go", symbolType: "function", score: 0.9},
+				{id: "2", filePath: "main.go", symbolType: "function", score: 0.8},
+			},
+			expected: 2,
+			check: func(t *testing.T, results []mergedResult) {
+				if len(results) != 2 {
+					t.Errorf("Expected 2 results, got %d", len(results))
+				}
+			},
+		},
+		{
+			name: "Group documentation chunks from same file and signature",
+			input: []mergedResult{
+				{
+					id: "chunk_1", filePath: tempFilePath, symbolType: "documentation", signature: "### Intro",
+					startLine: 1, endLine: 3, score: 0.8,
+				},
+				{
+					id: "chunk_2", filePath: tempFilePath, symbolType: "documentation", signature: "### Intro",
+					startLine: 4, endLine: 6, score: 0.9,
+				},
+				// This one is in a different signature
+				{
+					id: "chunk_3", filePath: tempFilePath, symbolType: "documentation", signature: "### Setup",
+					startLine: 8, endLine: 10, score: 0.5,
+				},
+				// This one is code, ignore grouping
+				{
+					id: "chunk_4", filePath: tempFilePath, symbolType: "code_block", signature: "### Intro",
+					startLine: 7, endLine: 7, score: 0.85,
+				},
+			},
+			// Expect: 1 merged block for "### Intro", 1 block for "### Setup".
+			// Note: chunk_4 has "code_block" type! Code blocks in markdown also get grouped!
+			expected: 2,
+			check: func(t *testing.T, results []mergedResult) {
+				if len(results) != 2 {
+					t.Fatalf("Expected 2 results, got %d", len(results))
+				}
+				
+				// results are sorted by score. The merged "### Intro" should have max score 0.9
+				if results[0].score != 0.9 {
+					t.Errorf("Expected max score 0.9, got %v", results[0].score)
+				}
+				
+				// Check start/end line bounds for the merged "### Intro"
+				if results[0].startLine != 1 || results[0].endLine != 7 {
+					t.Errorf("Expected lines 1-7, got %d-%d", results[0].startLine, results[0].endLine)
+				}
+				
+				// Verify the content was loaded from disk and contains Lines A to G (1 to 7)
+				if !strings.Contains(results[0].content, "Line A") || !strings.Contains(results[0].content, "Line G") {
+					t.Errorf("Merged content does not match expected lines from disk")
+				}
+				
+				// Setup should be untouched
+				if results[1].signature != "### Setup" {
+					t.Errorf("Expected second result to be '### Setup'")
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tool.groupDocsByTree(tc.input)
+			if len(got) != tc.expected {
+				t.Errorf("Expected %d results, got %d", tc.expected, len(got))
+			}
+			tc.check(t, got)
+		})
+	}
+}

--- a/internal/service/tools/smart_search_test.go
+++ b/internal/service/tools/smart_search_test.go
@@ -17,7 +17,9 @@ func TestGroupDocsByTree(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		lines[i] = "Line " + string(rune('A'+i)) // Line A, Line B, etc.
 	}
-	os.WriteFile(tempFilePath, []byte(strings.Join(lines, "\n")), 0644)
+	if err := os.WriteFile(tempFilePath, []byte(strings.Join(lines, "\n")), 0644); err != nil {
+		t.Fatalf("failed to create test file %s: %v", tempFilePath, err)
+	}
 
 	// Create tool instance (we only need the groupDocsByTree method)
 	tool := &SmartSearchTool{}
@@ -57,7 +59,7 @@ func TestGroupDocsByTree(t *testing.T) {
 					id: "chunk_3", filePath: tempFilePath, symbolType: "documentation", signature: "### Setup",
 					startLine: 8, endLine: 10, score: 0.5,
 				},
-				// This one is code, ignore grouping
+				// code_block is also a doc type, so it gets grouped under "### Intro"
 				{
 					id: "chunk_4", filePath: tempFilePath, symbolType: "code_block", signature: "### Intro",
 					startLine: 7, endLine: 7, score: 0.85,


### PR DESCRIPTION
## Description
This PR addresses the issue of search result "pollution" when querying large documents. Previously, large Markdown, HTML, YAML, or JSON files indexed with TreeSitter would dominate the top search results with multiple fragmented chunks, pushing out relevant backend code. 

**Changes included:**
1. **Tree-based Chunk Merging (Deduplication):** A post-retrieval processing step `groupDocsByTree` that intelligently merges adjacent or overlapping chunks from the same file and AST signature back into a single cohesive block. It safely loads any missing gap lines directly from disk.
2. **Strict Search Modes:** Added a new `Mode` field to the `rag_search` tool (`strict_code`, `strict_docs`, `all`), allowing AI agents to explicitly filter out documentation or code to avoid context pollution.
3. Added robust unit tests verifying gap retrieval, graceful fallbacks, and multi-file merging prevention.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have formatted my code with `go fmt ./...`
- [x] I have run tests `go test ./...` and they pass
- [x] I have verified integration with Ollama/Qdrant (if applicable)
- [x] I have updated the documentation accordingly