### PR TITLE
fix: prevent nested git repos from being treated as separate workspaces

### DIFF
--- a/pkg/workspace/registry/find_parent_test.go
+++ b/pkg/workspace/registry/find_parent_test.go
@@ -1,0 +1,125 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+// newTestRegistry creates a Registry with entries populated in-memory only (no disk I/O).
+func newTestRegistry(entries ...*Entry) *Registry {
+	r := &Registry{
+		entries:    make(map[string]*Entry),
+		candidates: make(map[string]*CandidateEntry),
+		indexRoot:  make(map[string]string),
+		indexName:  make(map[string][]string),
+		clock:      time.Now,
+		audit:      noopAuditSink{},
+	}
+	for _, e := range entries {
+		r.addEntry(e)
+	}
+	return r
+}
+
+func TestFindParentWorkspace(t *testing.T) {
+	r := newTestRegistry(&Entry{
+		ID:   hashRoot("/home/user/projects/big-project"),
+		Root: "/home/user/projects/big-project",
+		Name: "big-project",
+	})
+
+	tests := []struct {
+		name      string
+		path      string
+		wantRoot  string
+		wantFound bool
+	}{
+		{
+			name:      "child directory matches parent",
+			path:      "/home/user/projects/big-project/submodule/graph",
+			wantRoot:  "/home/user/projects/big-project",
+			wantFound: true,
+		},
+		{
+			name:      "deep nested child matches",
+			path:      "/home/user/projects/big-project/a/b/c/d",
+			wantRoot:  "/home/user/projects/big-project",
+			wantFound: true,
+		},
+		{
+			name:      "same path does not match (not strictly inside)",
+			path:      "/home/user/projects/big-project",
+			wantRoot:  "",
+			wantFound: false,
+		},
+		{
+			name:      "sibling directory does not match",
+			path:      "/home/user/projects/other-project",
+			wantRoot:  "",
+			wantFound: false,
+		},
+		{
+			name:      "parent directory does not match",
+			path:      "/home/user/projects",
+			wantRoot:  "",
+			wantFound: false,
+		},
+		{
+			name:      "similar prefix but different dir does not match",
+			path:      "/home/user/projects/big-project-v2/src",
+			wantRoot:  "",
+			wantFound: false,
+		},
+		{
+			name:      "empty path returns not found",
+			path:      "",
+			wantRoot:  "",
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root, found := r.FindParentWorkspace(tt.path)
+			if found != tt.wantFound {
+				t.Errorf("FindParentWorkspace(%q) found=%v, want %v", tt.path, found, tt.wantFound)
+			}
+			if root != tt.wantRoot {
+				t.Errorf("FindParentWorkspace(%q) root=%q, want %q", tt.path, root, tt.wantRoot)
+			}
+		})
+	}
+}
+
+func TestFindParentWorkspacePicksDeepest(t *testing.T) {
+	r := newTestRegistry(
+		&Entry{
+			ID:   hashRoot("/home/user/projects"),
+			Root: "/home/user/projects",
+			Name: "projects",
+		},
+		&Entry{
+			ID:   hashRoot("/home/user/projects/monorepo"),
+			Root: "/home/user/projects/monorepo",
+			Name: "monorepo",
+		},
+	)
+
+	// A path inside monorepo should match monorepo (the deepest parent), not projects
+	root, found := r.FindParentWorkspace("/home/user/projects/monorepo/packages/core")
+	if !found {
+		t.Fatal("expected to find parent workspace")
+	}
+	if root != "/home/user/projects/monorepo" {
+		t.Fatalf("expected deepest parent /home/user/projects/monorepo, got %s", root)
+	}
+
+	// A path inside projects but outside monorepo should match projects
+	root, found = r.FindParentWorkspace("/home/user/projects/other-app/src")
+	if !found {
+		t.Fatal("expected to find parent workspace")
+	}
+	if root != "/home/user/projects" {
+		t.Fatalf("expected parent /home/user/projects, got %s", root)
+	}
+}

--- a/pkg/workspace/registry/registry.go
+++ b/pkg/workspace/registry/registry.go
@@ -263,8 +263,9 @@ func (r *Registry) FindParentWorkspace(path string) (string, bool) {
 
 	for _, entry := range r.entries {
 		entryRoot := strings.ToLower(filepath.Clean(entry.Root))
-		// The path must be strictly inside the entry root (not equal to it)
-		prefix := entryRoot + string(filepath.Separator)
+		// The path must be strictly inside the entry root (not equal to it).
+		// TrimRight avoids double separator when entryRoot is "/" or "C:\".
+		prefix := strings.TrimRight(entryRoot, string(filepath.Separator)) + string(filepath.Separator)
 		if strings.HasPrefix(cleanPath, prefix) {
 			// Pick the deepest (most specific) parent
 			if len(entryRoot) > bestLen {

--- a/pkg/workspace/registry/registry.go
+++ b/pkg/workspace/registry/registry.go
@@ -243,6 +243,43 @@ func (r *Registry) LookupByRoot(root string) (*Entry, bool) {
 	return r.entries[id], true
 }
 
+// FindParentWorkspace checks if the given path is a subdirectory of any
+// registered workspace. If multiple parents exist (nested registrations),
+// returns the most specific (deepest) parent root. Returns ("", false) if
+// no parent found.
+// This prevents nested git repos (submodules, vendored projects) from being
+// treated as independent workspaces when they live inside an already-indexed project.
+func (r *Registry) FindParentWorkspace(path string) (string, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	cleanPath := strings.ToLower(filepath.Clean(path))
+	if cleanPath == "" {
+		return "", false
+	}
+
+	var bestRoot string
+	var bestLen int
+
+	for _, entry := range r.entries {
+		entryRoot := strings.ToLower(filepath.Clean(entry.Root))
+		// The path must be strictly inside the entry root (not equal to it)
+		prefix := entryRoot + string(filepath.Separator)
+		if strings.HasPrefix(cleanPath, prefix) {
+			// Pick the deepest (most specific) parent
+			if len(entryRoot) > bestLen {
+				bestLen = len(entryRoot)
+				bestRoot = entry.Root // preserve original casing
+			}
+		}
+	}
+
+	if bestRoot == "" {
+		return "", false
+	}
+	return bestRoot, true
+}
+
 // LookupByName returns entries matching the provided name.
 func (r *Registry) LookupByName(name string) []*Entry {
 	r.mu.Lock()

--- a/pkg/workspace/resolver/resolver.go
+++ b/pkg/workspace/resolver/resolver.go
@@ -21,6 +21,10 @@ type Registry interface {
 	PromoteCandidate(ctx context.Context, root, client string, executionSucceeded bool) error
 	RegisterWorkspace(root, name, client string) error
 	GetActiveWorkspace() (string, error)
+	// FindParentWorkspace checks if the given path is a subdirectory
+	// of any already-registered workspace. Returns the parent root
+	// and true if found, or ("", false) if no parent exists.
+	FindParentWorkspace(path string) (string, bool)
 }
 
 // RootValidator ensures resolved roots are within allowed boundaries.
@@ -162,6 +166,25 @@ func (r *Resolver) handleFilePath(ctx context.Context, path string) (*contract.R
 			Reason:  contract.ReasonInvalidPath,
 		}
 	}
+
+	// Guard: if the detected root is a subdirectory of an already-registered
+	// workspace, prefer the parent. This prevents nested git repos (submodules,
+	// vendored projects, monorepo sub-packages) from being treated as separate
+	// workspaces when they live inside a project that is already indexed.
+	if r.deps.Registry != nil {
+		if parentRoot, found := r.deps.Registry.FindParentWorkspace(result.Root); found {
+			r.log(ctx, "nested_workspace_override", map[string]any{
+				"detected_root": result.Root,
+				"parent_root":   parentRoot,
+				"reason":        "detected root is subdirectory of registered workspace",
+			})
+			result.Root = parentRoot
+			result.Reason = contract.ReasonFilePath
+			result.Source = "nested_workspace_override"
+			result.Confidence = 0.90 // slightly lower than direct detection
+		}
+	}
+
 	r.log(ctx, "file_path", map[string]any{"root": result.Root, "source": "file_path"})
 	if result.Source == "" {
 		result.Source = "file_path"

--- a/pkg/workspace/resolver/resolver.go
+++ b/pkg/workspace/resolver/resolver.go
@@ -185,7 +185,7 @@ func (r *Resolver) handleFilePath(ctx context.Context, path string) (*contract.R
 		}
 	}
 
-	r.log(ctx, "file_path", map[string]any{"root": result.Root, "source": "file_path"})
+	r.log(ctx, "file_path", map[string]any{"root": result.Root, "source": result.Source})
 	if result.Source == "" {
 		result.Source = "file_path"
 	}

--- a/pkg/workspace/resolver/resolver_test.go
+++ b/pkg/workspace/resolver/resolver_test.go
@@ -56,6 +56,32 @@ func TestResolveFilePath(t *testing.T) {
 	}
 }
 
+func TestResolveFilePathNestedWorkspaceOverride(t *testing.T) {
+	// Detector finds /tmp/parent/nested as the workspace root (has its own .git)
+	detector := &fakeDetector{candidate: &contract.WorkspaceCandidate{
+		Root:   "/tmp/parent/nested",
+		Reason: contract.ReasonFilePath,
+	}}
+	// Registry knows /tmp/parent is an already-registered workspace
+	reg := &fakeRegistry{parentRoot: "/tmp/parent"}
+	r := New(Dependencies{Detector: detector, Registry: reg})
+	req := contract.ResolveWorkspaceRequest{FilePath: "/tmp/parent/nested/src/main.py"}
+
+	resp, err := r.Resolve(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.ResolvedRoot != "/tmp/parent" {
+		t.Fatalf("expected parent root /tmp/parent, got %s", resp.ResolvedRoot)
+	}
+	if resp.PathResolutionSource != "nested_workspace_override" {
+		t.Fatalf("expected source nested_workspace_override, got %s", resp.PathResolutionSource)
+	}
+	if resp.PathResolutionConfidence >= 0.95 {
+		t.Fatalf("expected reduced confidence (<0.95), got %f", resp.PathResolutionConfidence)
+	}
+}
+
 func TestResolveAlias(t *testing.T) {
 	registry := &fakeRegistry{candidate: &contract.WorkspaceCandidate{Root: "/tmp/alias", Reason: contract.ReasonWorkspaceAlias}}
 	r := New(Dependencies{Registry: registry})
@@ -235,6 +261,7 @@ type fakeRegistry struct {
 	err           *contract.ResolveWorkspaceError
 	feedbackCount int
 	promoteCount  int
+	parentRoot    string // if set, FindParentWorkspace returns this
 }
 
 func (f *fakeRegistry) ResolveAlias(ctx context.Context, alias string) (*contract.WorkspaceCandidate, *contract.ResolveWorkspaceError) {
@@ -268,6 +295,9 @@ func (f *fakeRegistry) GetActiveWorkspace() (string, error) {
 }
 
 func (f *fakeRegistry) FindParentWorkspace(path string) (string, bool) {
+	if f.parentRoot != "" {
+		return f.parentRoot, true
+	}
 	return "", false
 }
 

--- a/pkg/workspace/resolver/resolver_test.go
+++ b/pkg/workspace/resolver/resolver_test.go
@@ -267,6 +267,10 @@ func (f *fakeRegistry) GetActiveWorkspace() (string, error) {
 	return "", nil
 }
 
+func (f *fakeRegistry) FindParentWorkspace(path string) (string, bool) {
+	return "", false
+}
+
 type fakeAnnotator struct {
 	branch       string
 	headSHA      string

--- a/pkg/workspace/tests/scenario_test.go
+++ b/pkg/workspace/tests/scenario_test.go
@@ -184,6 +184,10 @@ func (f *fakeRegistry) GetActiveWorkspace() (string, error) {
 	return "", nil
 }
 
+func (f *fakeRegistry) FindParentWorkspace(path string) (string, bool) {
+	return "", false
+}
+
 type branchstateAnnotator struct {
 	mgr *branchstate.Manager
 }


### PR DESCRIPTION
## Description

When a `file_path` points inside a subdirectory that has its own `.git` (submodules, vendored projects, cloned repos inline), the workspace detector would treat it as a **separate workspace** instead of using the already-registered parent project.

**Example:** Project `TradingAgents` contained `tradingagents/graph` with its own git repo. RagCode detected `tradingagents/graph` as an independent workspace, indexed only 7 Python files from the sub-folder, and scanned all languages (Go, HTML, docs) unnecessarily — instead of using the full `TradingAgents` project.

### Changes
- **`registry.go`**: Added `FindParentWorkspace(path) (string, bool)` — scans all registered entries to check if the given path is a strict subdirectory of an existing workspace. When multiple parents exist (nested registrations), returns the deepest (most specific) parent.
- **`resolver.go`**: Added `FindParentWorkspace` to the `Registry` interface. Modified `handleFilePath()` to check if the detected root is a child of a registered workspace — if so, overrides the candidate with the parent root (source: `nested_workspace_override`, confidence: 0.90).
- **`find_parent_test.go`** *(new)*: 9 unit tests covering child match, deep nesting, same-path rejection, sibling rejection, prefix collision safety (`big-project` vs `big-project-v2`), empty path, and deepest-parent selection.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have formatted my code with `go fmt ./...`
- [x] I have run tests `go test ./...` and they pass
- [ ] I have verified integration with Ollama/Qdrant (if applicable)
- [ ] I have updated the documentation accordingly
