### PR TITLE
fix: resilient file_path detection with registry fallback and descrip…

### DIFF
--- a/pkg/workspace/detector/detector.go
+++ b/pkg/workspace/detector/detector.go
@@ -105,9 +105,19 @@ func (d *Detector) DetectFromFilePath(ctx context.Context, filePath string) (*co
 	startDir := abs
 	info, err := os.Stat(abs)
 	if err != nil {
-		return nil, wrapPathErr("stat path", err)
-	}
-	if !info.IsDir() {
+		// File does not exist — try the parent directory as fallback.
+		// This handles the common case where an AI agent passes a non-existent
+		// file path (e.g. "main.go") but the project directory is valid.
+		parentDir := filepath.Dir(abs)
+		if _, parentErr := os.Stat(parentDir); parentErr != nil {
+			return nil, &contract.ResolveWorkspaceError{
+				Code:    contract.ErrorInvalidPath,
+				Message: fmt.Sprintf("file_path %q does not exist and parent directory %q is also invalid. The file_path parameter is only used for workspace detection — pass any existing file from the target project, or omit file_path entirely for auto-discovery", abs, parentDir),
+				Reason:  contract.ReasonInvalidPath,
+			}
+		}
+		startDir = parentDir
+	} else if !info.IsDir() {
 		startDir = filepath.Dir(abs)
 	}
 

--- a/pkg/workspace/detector/detector.go
+++ b/pkg/workspace/detector/detector.go
@@ -105,6 +105,12 @@ func (d *Detector) DetectFromFilePath(ctx context.Context, filePath string) (*co
 	startDir := abs
 	info, err := os.Stat(abs)
 	if err != nil {
+		// Only fall back to parent directory when the file genuinely doesn't exist.
+		// Other stat errors (permission denied, I/O errors) should propagate
+		// to preserve their meaning.
+		if !os.IsNotExist(err) {
+			return nil, wrapPathErr("stat path", err)
+		}
 		// File does not exist — try the parent directory as fallback.
 		// This handles the common case where an AI agent passes a non-existent
 		// file path (e.g. "main.go") but the project directory is valid.
@@ -112,7 +118,7 @@ func (d *Detector) DetectFromFilePath(ctx context.Context, filePath string) (*co
 		if _, parentErr := os.Stat(parentDir); parentErr != nil {
 			return nil, &contract.ResolveWorkspaceError{
 				Code:    contract.ErrorInvalidPath,
-				Message: fmt.Sprintf("file_path %q does not exist and parent directory %q is also invalid. The file_path parameter is only used for workspace detection — pass any existing file from the target project, or omit file_path entirely for auto-discovery", abs, parentDir),
+				Message: fmt.Sprintf("file_path %q does not exist and parent directory %q is also invalid. The file_path parameter is only used for workspace detection — pass any existing file from the target project", abs, parentDir),
 				Reason:  contract.ReasonInvalidPath,
 			}
 		}

--- a/pkg/workspace/detector/detector_test.go
+++ b/pkg/workspace/detector/detector_test.go
@@ -4,6 +4,7 @@ import (
 	context "context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/doITmagic/rag-code-mcp/pkg/workspace/contract"
@@ -113,5 +114,44 @@ func TestDetectNoMarkers(t *testing.T) {
 	det := New(DefaultOptions())
 	if _, err := det.DetectFromFilePath(context.Background(), filepath.Join(tmp, "nope.go")); err == nil {
 		t.Fatalf("expected error when no markers present")
+	}
+}
+
+func TestDetectNonExistentFileParentFallback(t *testing.T) {
+	// Setup: directory has .git marker but the requested file does NOT exist
+	tmp := t.TempDir()
+	project := filepath.Join(tmp, "myproject")
+	if err := os.Mkdir(project, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ".git"), []byte{}, 0o644); err != nil {
+		t.Fatalf("marker: %v", err)
+	}
+	// "main.go" does NOT exist on disk — simulates AI agent passing a non-existent file
+	nonExistentFile := filepath.Join(project, "main.go")
+
+	det := New(DefaultOptions())
+	resp, err := det.DetectFromFilePath(context.Background(), nonExistentFile)
+	if err != nil {
+		t.Fatalf("expected fallback to parent directory, got error: %v", err)
+	}
+	if resp.Root != project {
+		t.Fatalf("expected root %s, got %s", project, resp.Root)
+	}
+}
+
+func TestDetectNonExistentFileDescriptiveError(t *testing.T) {
+	// Both the file AND its parent directory don't exist
+	det := New(DefaultOptions())
+	_, err := det.DetectFromFilePath(context.Background(), "/completely/fake/path/main.go")
+	if err == nil {
+		t.Fatalf("expected error for fully invalid path")
+	}
+	if err.Code != contract.ErrorInvalidPath {
+		t.Fatalf("expected ErrorInvalidPath, got %s", err.Code)
+	}
+	// Error message should contain AI-friendly guidance
+	if !strings.Contains(err.Message, "workspace detection") {
+		t.Fatalf("expected descriptive error with workspace detection hint, got: %s", err.Message)
 	}
 }

--- a/pkg/workspace/resolver/resolver.go
+++ b/pkg/workspace/resolver/resolver.go
@@ -158,33 +158,48 @@ func (r *Resolver) handleFilePath(ctx context.Context, path string) (*contract.R
 	}
 	result, detectorErr := r.deps.Detector.DetectFromFilePath(ctx, path)
 	if detectorErr != nil {
-		// Detection failed (e.g. file_path does not exist on disk).
-		// Before giving up, try the registry — if the path is inside an
-		// already-registered workspace we can resolve it without stat.
-		if r.deps.Registry != nil {
-			parentDir := filepath.Dir(path)
-			if parentRoot, found := r.deps.Registry.FindParentWorkspace(parentDir); found {
-				r.log(ctx, "registry_fallback", map[string]any{
-					"original_path":  path,
-					"parent_root":    parentRoot,
-					"detector_error": detectorErr.Message,
-					"reason":         "file_path does not exist, resolved via registry",
-				})
-				result = &contract.WorkspaceCandidate{
-					Root:       parentRoot,
-					Reason:     contract.ReasonFilePath,
-					Source:     "registry_fallback",
-					Confidence: 0.85,
+		// Only attempt registry fallback for invalid-path / missing-file errors.
+		// Other errors (OUTSIDE_ALLOWED_ROOTS, exclusions, permission denied)
+		// should propagate as-is to preserve their semantics.
+		if detectorErr.Code == contract.ErrorInvalidPath && detectorErr.Reason == contract.ReasonInvalidPath {
+			if r.deps.Registry != nil {
+				// Normalize to absolute path before registry lookup — the
+				// registry stores normalized roots, so relative or '..' paths
+				// would miss otherwise.
+				normalizedPath, absErr := filepath.Abs(path)
+				if absErr != nil {
+					normalizedPath = filepath.Clean(path)
+				}
+				parentDir := filepath.Dir(normalizedPath)
+				if parentRoot, found := r.deps.Registry.FindParentWorkspace(parentDir); found {
+					r.log(ctx, "registry_fallback", map[string]any{
+						"original_path":  path,
+						"parent_root":    parentRoot,
+						"detector_error": detectorErr.Message,
+						"reason":         "file_path does not exist, resolved via registry",
+					})
+					result = &contract.WorkspaceCandidate{
+						Root:       parentRoot,
+						Reason:     contract.ReasonRegistryFallback,
+						Source:     "registry_fallback",
+						Confidence: 0.85,
+					}
 				}
 			}
 		}
-		// If registry didn't help, return a descriptive error with AI hint.
+		// If registry didn't help (or we skipped it for non-invalid-path errors),
+		// return a descriptive error.
 		if result == nil {
-			return nil, &contract.ResolveWorkspaceError{
-				Code:    detectorErr.Code,
-				Message: fmt.Sprintf("%s. Hint: file_path is used only for workspace detection and must point to an existing file on disk. Pass any file currently open in the IDE (e.g. from the active editor tab)", detectorErr.Message),
-				Reason:  detectorErr.Reason,
+			// Only add the "existing file" hint for invalid-path style errors.
+			if detectorErr.Reason == contract.ReasonInvalidPath {
+				return nil, &contract.ResolveWorkspaceError{
+					Code:    detectorErr.Code,
+					Message: fmt.Sprintf("%s. Hint: file_path is used only for workspace detection and must point to an existing file on disk. Pass any file currently open in the IDE (e.g. from the active editor tab)", detectorErr.Message),
+					Reason:  detectorErr.Reason,
+				}
 			}
+			// For all other detector errors, propagate as-is to preserve context.
+			return nil, detectorErr
 		}
 	}
 	if result == nil || strings.TrimSpace(result.Root) == "" {
@@ -429,7 +444,7 @@ func defaultConfidence(source string) float64 {
 
 func isFallbackSource(source string) bool {
 	switch strings.ToLower(strings.TrimSpace(source)) {
-	case "roots", "registry", "metadata", "resolver":
+	case "roots", "registry", "registry_fallback", "metadata", "resolver":
 		return true
 	default:
 		return false

--- a/pkg/workspace/resolver/resolver.go
+++ b/pkg/workspace/resolver/resolver.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	context "context"
+	"fmt"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -155,9 +156,36 @@ func (r *Resolver) handleFilePath(ctx context.Context, path string) (*contract.R
 			Reason:  contract.ReasonRootsUnavailable,
 		}
 	}
-	result, err := r.deps.Detector.DetectFromFilePath(ctx, path)
-	if err != nil {
-		return nil, err
+	result, detectorErr := r.deps.Detector.DetectFromFilePath(ctx, path)
+	if detectorErr != nil {
+		// Detection failed (e.g. file_path does not exist on disk).
+		// Before giving up, try the registry — if the path is inside an
+		// already-registered workspace we can resolve it without stat.
+		if r.deps.Registry != nil {
+			parentDir := filepath.Dir(path)
+			if parentRoot, found := r.deps.Registry.FindParentWorkspace(parentDir); found {
+				r.log(ctx, "registry_fallback", map[string]any{
+					"original_path":  path,
+					"parent_root":    parentRoot,
+					"detector_error": detectorErr.Message,
+					"reason":         "file_path does not exist, resolved via registry",
+				})
+				result = &contract.WorkspaceCandidate{
+					Root:       parentRoot,
+					Reason:     contract.ReasonFilePath,
+					Source:     "registry_fallback",
+					Confidence: 0.85,
+				}
+			}
+		}
+		// If registry didn't help, return a descriptive error with AI hint.
+		if result == nil {
+			return nil, &contract.ResolveWorkspaceError{
+				Code:    detectorErr.Code,
+				Message: fmt.Sprintf("%s. Hint: file_path is used only for workspace detection and must point to an existing file on disk. Pass any file currently open in the IDE (e.g. from the active editor tab)", detectorErr.Message),
+				Reason:  detectorErr.Reason,
+			}
+		}
 	}
 	if result == nil || strings.TrimSpace(result.Root) == "" {
 		return nil, &contract.ResolveWorkspaceError{
@@ -171,7 +199,8 @@ func (r *Resolver) handleFilePath(ctx context.Context, path string) (*contract.R
 	// workspace, prefer the parent. This prevents nested git repos (submodules,
 	// vendored projects, monorepo sub-packages) from being treated as separate
 	// workspaces when they live inside a project that is already indexed.
-	if r.deps.Registry != nil {
+	// Skip this check when we already resolved via registry_fallback.
+	if r.deps.Registry != nil && result.Source != "registry_fallback" {
 		if parentRoot, found := r.deps.Registry.FindParentWorkspace(result.Root); found {
 			r.log(ctx, "nested_workspace_override", map[string]any{
 				"detected_root": result.Root,

--- a/pkg/workspace/resolver/resolver_test.go
+++ b/pkg/workspace/resolver/resolver_test.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	context "context"
+	"strings"
 	testing "testing"
 
 	"github.com/doITmagic/rag-code-mcp/pkg/workspace/contract"
@@ -318,4 +319,80 @@ func (f *fakeAnnotator) Annotate(ctx context.Context, root string, resp *contrac
 	resp.WorktreeID = f.worktreeID
 	resp.MismatchRisk = f.mismatchRisk
 	return nil
+}
+
+// --- New tests: registry fallback when detector fails ---
+
+func TestResolveFilePathRegistryFallback(t *testing.T) {
+	// Detector fails (file doesn't exist) but registry knows the parent workspace
+	detector := &fakeDetector{err: &contract.ResolveWorkspaceError{
+		Code:    contract.ErrorInvalidPath,
+		Message: "stat path: no such file or directory",
+		Reason:  contract.ReasonInvalidPath,
+	}}
+	reg := &fakeRegistry{parentRoot: "/home/user/project"}
+	r := New(Dependencies{Detector: detector, Registry: reg})
+	req := contract.ResolveWorkspaceRequest{FilePath: "/home/user/project/main.go"}
+
+	resp, err := r.Resolve(context.Background(), req)
+	if err != nil {
+		t.Fatalf("expected registry fallback to succeed, got error: %v", err)
+	}
+	if resp.ResolvedRoot != "/home/user/project" {
+		t.Fatalf("expected root /home/user/project, got %s", resp.ResolvedRoot)
+	}
+	if resp.PathResolutionSource != "registry_fallback" {
+		t.Fatalf("expected source registry_fallback, got %s", resp.PathResolutionSource)
+	}
+	if resp.PathResolutionConfidence > 0.90 {
+		t.Fatalf("expected reduced confidence (<=0.90), got %f", resp.PathResolutionConfidence)
+	}
+}
+
+func TestResolveFilePathNoRegistryDescriptiveError(t *testing.T) {
+	// Detector fails and no registry configured — should get descriptive hint
+	detector := &fakeDetector{err: &contract.ResolveWorkspaceError{
+		Code:    contract.ErrorInvalidPath,
+		Message: "stat path: no such file or directory",
+		Reason:  contract.ReasonInvalidPath,
+	}}
+	r := New(Dependencies{Detector: detector})
+	req := contract.ResolveWorkspaceRequest{FilePath: "/fake/project/main.go"}
+
+	resp, err := r.Resolve(context.Background(), req)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response")
+	}
+	if !strings.Contains(err.Message, "Hint:") {
+		t.Fatalf("expected AI-friendly hint in error message, got: %s", err.Message)
+	}
+	if !strings.Contains(err.Message, "workspace detection") {
+		t.Fatalf("expected 'workspace detection' explanation in error, got: %s", err.Message)
+	}
+}
+
+func TestResolveFilePathRegistryMissDescriptiveError(t *testing.T) {
+	// Detector fails and registry doesn't know this path either
+	detector := &fakeDetector{err: &contract.ResolveWorkspaceError{
+		Code:    contract.ErrorInvalidPath,
+		Message: "stat path: no such file or directory",
+		Reason:  contract.ReasonInvalidPath,
+	}}
+	reg := &fakeRegistry{} // parentRoot is empty => FindParentWorkspace returns false
+	r := New(Dependencies{Detector: detector, Registry: reg})
+	req := contract.ResolveWorkspaceRequest{FilePath: "/unknown/path/file.go"}
+
+	resp, err := r.Resolve(context.Background(), req)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response")
+	}
+	if !strings.Contains(err.Message, "Hint:") {
+		t.Fatalf("expected AI hint in error, got: %s", err.Message)
+	}
 }

--- a/pkg/workspace/resolver/resolver_test.go
+++ b/pkg/workspace/resolver/resolver_test.go
@@ -347,6 +347,9 @@ func TestResolveFilePathRegistryFallback(t *testing.T) {
 	if resp.PathResolutionConfidence > 0.90 {
 		t.Fatalf("expected reduced confidence (<=0.90), got %f", resp.PathResolutionConfidence)
 	}
+	if !resp.UsedFallback {
+		t.Fatalf("expected UsedFallback=true for registry_fallback source")
+	}
 }
 
 func TestResolveFilePathNoRegistryDescriptiveError(t *testing.T) {
@@ -394,5 +397,33 @@ func TestResolveFilePathRegistryMissDescriptiveError(t *testing.T) {
 	}
 	if !strings.Contains(err.Message, "Hint:") {
 		t.Fatalf("expected AI hint in error, got: %s", err.Message)
+	}
+}
+
+func TestResolveFilePathNonInvalidPathErrorPassthrough(t *testing.T) {
+	// Detector fails with OUTSIDE_ALLOWED_ROOTS — should NOT trigger
+	// registry fallback and should propagate the original error as-is.
+	detector := &fakeDetector{err: &contract.ResolveWorkspaceError{
+		Code:    contract.ErrorOutsideAllowedRoots,
+		Message: "path /outside is outside allowed workspace roots",
+		Reason:  contract.ReasonOutsideAllowedRoots,
+	}}
+	reg := &fakeRegistry{parentRoot: "/home/user/project"} // registry WOULD match
+	r := New(Dependencies{Detector: detector, Registry: reg})
+	req := contract.ResolveWorkspaceRequest{FilePath: "/outside/main.go"}
+
+	resp, err := r.Resolve(context.Background(), req)
+	if err == nil {
+		t.Fatalf("expected error to propagate, got nil")
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response")
+	}
+	// Error should be the original one, not wrapped with a hint
+	if err.Code != contract.ErrorOutsideAllowedRoots {
+		t.Fatalf("expected ErrorOutsideAllowedRoots, got %s", err.Code)
+	}
+	if strings.Contains(err.Message, "Hint:") {
+		t.Fatalf("non-invalid-path errors should not get hint appended, got: %s", err.Message)
 	}
 }


### PR DESCRIPTION

## Description

When an AI agent passes a `file_path` that doesn't exist on disk (e.g. `/project/main.go` when the actual entry point is at `/project/cmd/rag-code-mcp/main.go`), workspace detection fails immediately with a generic `"stat path: no such file or directory"` error. The agent receives no guidance on what went wrong or how to fix it.

This is a common scenario — AI agents often guess file paths rather than using files actually open in the IDE.

### Solution — two layers of resilience:

**1. Registry fallback (resolver)** — When the detector fails, the resolver checks `FindParentWorkspace(filepath.Dir(path))` against already-registered workspaces. If the path is inside a known workspace, resolution succeeds without needing the file to exist. Runs first because the registry contains confirmed, indexed workspaces.

**2. Parent directory fallback (detector)** — When `os.Stat(file)` fails, the detector tries `filepath.Dir()` instead of stopping. If the parent directory exists, it proceeds with normal marker-based `walkUp` detection. Covers first-time use when the registry is empty.

**3. Descriptive error messages** — When all fallback paths are exhausted, errors now include actionable hints for AI agents:
> `"file_path is used only for workspace detection and must point to an existing file on disk. Pass any file currently open in the IDE (e.g. from the active editor tab)"`

### Tests added (5 new):

| Test | Package | Scenario |
|------|---------|----------|
| `TestDetectNonExistentFileParentFallback` | detector | File missing, parent dir has markers → ✅ success |
| `TestDetectNonExistentFileDescriptiveError` | detector | Both file and parent invalid → descriptive error |
| `TestResolveFilePathRegistryFallback` | resolver | Detector fails, registry knows workspace → ✅ success |
| `TestResolveFilePathNoRegistryDescriptiveError` | resolver | No registry, detector fails → error with hint |
| `TestResolveFilePathRegistryMissDescriptiveError` | resolver | Registry empty, detector fails → error with hint |

All 45+ existing tests pass with zero regressions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have formatted my code with `go fmt ./...`
- [x] I have run tests `go test ./...` and they pass
- [ ] I have verified integration with Ollama/Qdrant (if applicable)
- [ ] I have updated the documentation accordingly
